### PR TITLE
Fix 502: disable ddtrace openai_agents auto-patch

### DIFF
--- a/chatbot.py
+++ b/chatbot.py
@@ -16,8 +16,9 @@ from logging_config import get_logger
 
 # Datadog LLM Observability: ddtrace 4.0.0's openai_agents integration is
 # incompatible with openai-agents >=0.9.0 (missing _run_single_turn).
-# Disable the auto-patch before importing the agents SDK; the underlying
-# openai calls are still traced by ddtrace's openai integration.
+# The primary fix is DD_TRACE_OPENAI_AGENTS_ENABLED=false in docker-compose
+# (must be set before ddtrace-run starts).  This setdefault is a fallback
+# for local development without docker-compose env vars.
 os.environ.setdefault("DD_TRACE_OPENAI_AGENTS_ENABLED", "false")
 
 from agents import Agent, Runner, function_tool, set_tracing_disabled  # noqa: E402

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -38,6 +38,7 @@ services:
       - DD_LLMOBS_ENABLED=1
       - DD_LLMOBS_ML_APP=devtoolscrape
       - DD_CODE_ORIGIN_FOR_SPANS_ENABLED=true
+      - DD_TRACE_OPENAI_AGENTS_ENABLED=false
       - GUNICORN_BIND=0.0.0.0:9000
     restart: unless-stopped
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       - DD_LLMOBS_ENABLED=1
       - DD_LLMOBS_ML_APP=devtoolscrape
       - DD_CODE_ORIGIN_FOR_SPANS_ENABLED=true
+      - DD_TRACE_OPENAI_AGENTS_ENABLED=false
       - GUNICORN_BIND=0.0.0.0:9000
     env_file:
       - .env


### PR DESCRIPTION
## Summary
- Adds DD_TRACE_OPENAI_AGENTS_ENABLED=false to both docker-compose files
- Fixes fatal crash when ddtrace IAST loader propagates AttributeError from incompatible openai_agents patch (AgentRunner._run_single_turn removed in openai-agents >=0.9.0)
- Updates chatbot.py comment to clarify the env var must be set before ddtrace-run starts

## Root cause
ddtrace 4.0.0 with DD_IAST_ENABLED=true uses _exec_iast_patched_module which causes the openai_agents patching error to propagate as a fatal ImportError instead of being caught gracefully.

## Test plan
- [x] All 125 tests pass locally
- [x] Hotfix applied directly to production server -- site confirmed healthy at https://devtoolscrape.com/health

Generated with [Claude Code](https://claude.com/claude-code)