### PR TITLE
Integrate Datadog Prompt Management and Prompt Tracking

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install --find-links=https://dd-trace-py-builds.s3.amazonaws.com/96035140/index.html -r requirements.txt
           pip install pytest
 
       - name: Configure Datadog Test Optimization

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,9 @@ ENV DD_GIT_COMMIT_SHA=${DD_GIT_COMMIT_SHA}
 ENV DD_VERSION=${DD_VERSION}
 
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir \
+    --find-links=https://dd-trace-py-builds.s3.amazonaws.com/96035140/index.html \
+    -r requirements.txt
 
 COPY . .
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,3 +1,12 @@
+### 2026-02-17T16:30:00Z
+- Integrated Datadog Prompt Management and Prompt Tracking into the chatbot.
+- `chatbot.py`: imports `LLMObs` from `ddtrace.llmobs`, fetches the system prompt at runtime via `LLMObs.get_prompt("devtools-assistant", label="production", fallback=_FALLBACK_PROMPT)` instead of using a hardcoded string. Agent is now created per-request with the fetched instructions, allowing prompt changes from the Datadog UI to propagate within ~60s (cache TTL). The agent run is wrapped in `LLMObs.annotation_context(prompt=prompt.to_annotation_dict())` for prompt tracking in LLM Observability traces.
+- Added `_get_prompt()` and `_instructions_from_prompt()` helpers. The latter handles both text templates (str) and chat templates (list of message dicts) by extracting the system message.
+- Upgraded ddtrace from >=4.4.0 to ==4.5.0rc1 (pre-release with Prompt Management SDK). Updated `requirements.txt`, `Dockerfile`, and CI workflow to install from the S3 pre-release index (`https://dd-trace-py-builds.s3.amazonaws.com/96035140/index.html`).
+- Added `DD_API_KEY=${DATADOG_API_KEY}` to the app container environment in both `docker-compose.yml` and `docker-compose.yaml` (required by the prompt fetch HTTP API).
+- Updated `tests/conftest.py` with `_FakeManagedPrompt` and `_FakeAnnotationContext` stubs, plus `get_prompt()` and `annotation_context()` methods on `_FakeLLMObs`. All 139 tests pass.
+- Next step: create the "devtools-assistant" prompt in the Datadog UI (AI Observability > Prompts > New Prompt) with the system instructions and assign the "production" label.
+
 ### 2026-02-17T15:55:00Z
 - Fixed `sqlite3.OperationalError: fts5: syntax error near "/"` in chatbot search (PR #22, merged).
 - The FTS5 query sanitizer only stripped `"`, `*`, `(`, `)` but FTS5 also treats `/`, `+`, `-`, `^`, `:`, `{`, `}` as special syntax. Agent-generated queries like "CI/CD" triggered the error.

--- a/chatbot.py
+++ b/chatbot.py
@@ -13,6 +13,7 @@ load_dotenv(BASE_DIR / ".env")
 
 from agents import Agent, Runner, function_tool
 from agents.items import ToolCallOutputItem
+from ddtrace.llmobs import LLMObs
 
 from database import count_all_startups, search_startups
 from logging_config import get_logger
@@ -23,11 +24,14 @@ _CHATBOT_MODEL = os.getenv("CHATBOT_MODEL", "gpt-4o-mini")
 _CHATBOT_MAX_TURNS = max(1, int(os.getenv("CHATBOT_MAX_TURNS", "3")))
 _MAX_TOOLS_IN_CONTEXT = int(os.getenv("CHATBOT_MAX_TOOLS", "10"))
 
+_PROMPT_ID = "devtools-assistant"
+_PROMPT_LABEL = os.getenv("CHATBOT_PROMPT_LABEL", "production")
+
 # FTS5 operator pattern to sanitize user-supplied queries
 _FTS5_OPERATORS = re.compile(r'["\*\(\)\+\-\^:/\{\}]')
 _FTS5_KEYWORDS = re.compile(r'\b(AND|OR|NOT|NEAR)\b', re.IGNORECASE)
 
-_SYSTEM_PROMPT = """\
+_FALLBACK_PROMPT = """\
 You are a helpful assistant for DevTools Scraper, a developer tools discovery platform.
 Your job is to recommend developer tools from our database based on what the user asks.
 
@@ -81,12 +85,42 @@ def count_tools() -> str:
     return str(total)
 
 
-_agent = Agent(
-    name="DevToolsAssistant",
-    instructions=_SYSTEM_PROMPT,
-    model=_CHATBOT_MODEL,
-    tools=[search_tools, count_tools],
-)
+def _get_prompt() -> Any:
+    """Fetch the chatbot system prompt from Datadog Prompt Management.
+
+    Returns:
+        A ManagedPrompt backed by the Datadog-hosted prompt, or
+        a fallback-backed prompt if the fetch fails.
+    """
+    return LLMObs.get_prompt(
+        _PROMPT_ID,
+        label=_PROMPT_LABEL,
+        fallback=_FALLBACK_PROMPT,
+    )
+
+
+def _instructions_from_prompt(prompt: Any) -> str:
+    """Extract a plain instruction string from a managed prompt.
+
+    Handles both text templates (returns str) and chat templates
+    (returns list of message dicts) by pulling the system message.
+
+    Args:
+        prompt: A ManagedPrompt from LLMObs.get_prompt().
+
+    Returns:
+        The instruction string to pass to the agent.
+    """
+    rendered = prompt.format()
+    if isinstance(rendered, str):
+        return rendered
+    # Chat template: prefer the system message content.
+    for msg in rendered:
+        if isinstance(msg, dict) and msg.get("role") == "system":
+            return msg["content"]
+    if rendered and isinstance(rendered[0], dict):
+        return rendered[0].get("content", _FALLBACK_PROMPT)
+    return _FALLBACK_PROMPT
 
 
 def _collect_tools(result: Any) -> list[dict[str, Any]]:
@@ -113,8 +147,9 @@ def _collect_tools(result: Any) -> list[dict[str, Any]]:
 def generate_chat_response(user_message: str) -> dict[str, Any]:
     """Generate a chatbot response for a user's natural language question.
 
-    Runs the OpenAI Agents SDK agent which can search the tools database
-    and produce a conversational recommendation.
+    Fetches the latest prompt from Datadog Prompt Management, creates an
+    agent with those instructions, and wraps the run in an annotation
+    context for prompt tracking in LLM Observability.
 
     Args:
         user_message: The user's question (should be pre-validated by caller).
@@ -123,11 +158,23 @@ def generate_chat_response(user_message: str) -> dict[str, Any]:
         Dict with "response" (str) and "tools" (list of matched tool dicts).
     """
     try:
-        result = Runner.run_sync(
-            _agent,
-            input=user_message,
-            max_turns=_CHATBOT_MAX_TURNS,
+        prompt = _get_prompt()
+        instructions = _instructions_from_prompt(prompt)
+
+        agent = Agent(
+            name="DevToolsAssistant",
+            instructions=instructions,
+            model=_CHATBOT_MODEL,
+            tools=[search_tools, count_tools],
         )
+
+        with LLMObs.annotation_context(prompt=prompt.to_annotation_dict()):
+            result = Runner.run_sync(
+                agent,
+                input=user_message,
+                max_turns=_CHATBOT_MAX_TURNS,
+            )
+
         response_text = result.final_output or ""
         tools = _collect_tools(result)
 
@@ -138,6 +185,7 @@ def generate_chat_response(user_message: str) -> dict[str, Any]:
                 "message_length": len(user_message),
                 "tools_found": len(tools),
                 "response_length": len(response_text),
+                "prompt_version": getattr(prompt, "version", "unknown"),
             },
         )
         return {"response": response_text, "tools": tools}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -35,6 +35,7 @@ services:
       - DD_APPSEC_ENABLED=true
       - DD_IAST_ENABLED=true
       - DD_IAST_REQUEST_SAMPLING=100
+      - DD_API_KEY=${DATADOG_API_KEY}
       - DD_LLMOBS_ENABLED=1
       - DD_LLMOBS_ML_APP=devtoolscrape
       - DD_CODE_ORIGIN_FOR_SPANS_ENABLED=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       - DD_APPSEC_ENABLED=true
       - DD_IAST_ENABLED=true
       - DD_IAST_REQUEST_SAMPLING=100
+      - DD_API_KEY=${DATADOG_API_KEY}
       - DD_LLMOBS_ENABLED=1
       - DD_LLMOBS_ML_APP=devtoolscrape
       - DD_CODE_ORIGIN_FOR_SPANS_ENABLED=true

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ openai-agents>=0.7.0,<0.8.0
 python-dotenv>=1.1.1,<2.0.0
 lxml>=6.0.0,<7.0.0
 gunicorn>=21.0.0,<22.0.0
-ddtrace>=4.4.0,<5.0.0
+ddtrace==4.5.0rc1
 python-json-logger>=2.0.7,<3.0.0
 cachetools>=5.3.3,<7.0.0
 tenacity>=9.0.0,<10.0.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,12 +25,50 @@ def stub_external_sdks():
     llmobs_module = types.ModuleType("ddtrace.llmobs")
     tracer_module = types.ModuleType("ddtrace.tracer")
 
+    class _FakeManagedPrompt:
+        """Stub for ddtrace ManagedPrompt returned by LLMObs.get_prompt()."""
+
+        def __init__(self, text: str):
+            self._text = text
+            self.id = "devtools-assistant"
+            self.version = "fallback"
+            self.label = "production"
+
+        def format(self, **kwargs):
+            return self._text
+
+        def to_annotation_dict(self, **kwargs):
+            return {"prompt_id": self.id, "version": self.version}
+
+    class _FakeAnnotationContext:
+        """Stub for LLMObs.annotation_context() context manager."""
+
+        def __init__(self, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            return False
+
     class _FakeLLMObs:
         calls = []
 
         @classmethod
         def enable(cls, *args, **kwargs):
             cls.calls.append((args, kwargs))
+
+        @classmethod
+        def get_prompt(cls, prompt_id, label=None, fallback=None):
+            """Return a fake ManagedPrompt backed by the fallback text."""
+            text = fallback if isinstance(fallback, str) else ""
+            return _FakeManagedPrompt(text)
+
+        @classmethod
+        def annotation_context(cls, **kwargs):
+            """Return a no-op context manager."""
+            return _FakeAnnotationContext(**kwargs)
 
     class _FakeSpan:
         def __enter__(self):


### PR DESCRIPTION
## Summary
- Fetches the chatbot system prompt at runtime via `LLMObs.get_prompt("devtools-assistant")` with fallback to the hardcoded prompt, enabling prompt updates from the Datadog UI without redeployment
- Wraps agent runs in `LLMObs.annotation_context()` for prompt tracking in LLM Observability traces (version, template, variables visible in trace details)
- Upgrades ddtrace to 4.5.0rc1 (pre-release with Prompt Management SDK) from S3 pre-release index
- Adds `DD_API_KEY` to app container environment in both compose files for prompt fetch HTTP API
- Updates test conftest with `_FakeManagedPrompt` and `_FakeAnnotationContext` stubs

## Test plan
- [x] All 139 tests pass locally
- [ ] CI passes on PR
- [ ] Deploy to production and verify /api/chat still returns 200
- [ ] Create "devtools-assistant" prompt in Datadog UI and verify it is fetched at runtime
- [ ] Verify prompt metadata appears in LLM Observability traces

🤖 Generated with [Claude Code](https://claude.com/claude-code)