### PR TITLE
Fix chatbot crash: use Prompt Tracking instead of unavailable Prompt Management

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,11 +1,15 @@
+### 2026-02-17T17:30:00Z
+- Fixed `AttributeError: type object 'LLMObs' has no attribute 'get_prompt'` in production.
+- ddtrace 4.5.0rc1 does NOT include the Prompt Management API (`LLMObs.get_prompt()`). That API was documented but not shipped in this pre-release build.
+- Replaced the Prompt Management approach with Prompt Tracking only: `LLMObs.annotation_context(prompt=_PROMPT_TRACKING)` wraps the agent run, passing a dict with `id`, `template`, and `version` so LLM Observability traces include the prompt metadata.
+- Restored module-level `_agent` (no per-request creation needed without runtime prompt fetching).
+- Removed `_get_prompt()`, `_instructions_from_prompt()`, and `_FakeManagedPrompt` stub from conftest.py.
+
 ### 2026-02-17T16:30:00Z
-- Integrated Datadog Prompt Management and Prompt Tracking into the chatbot.
-- `chatbot.py`: imports `LLMObs` from `ddtrace.llmobs`, fetches the system prompt at runtime via `LLMObs.get_prompt("devtools-assistant", label="production", fallback=_FALLBACK_PROMPT)` instead of using a hardcoded string. Agent is now created per-request with the fetched instructions, allowing prompt changes from the Datadog UI to propagate within ~60s (cache TTL). The agent run is wrapped in `LLMObs.annotation_context(prompt=prompt.to_annotation_dict())` for prompt tracking in LLM Observability traces.
-- Added `_get_prompt()` and `_instructions_from_prompt()` helpers. The latter handles both text templates (str) and chat templates (list of message dicts) by extracting the system message.
-- Upgraded ddtrace from >=4.4.0 to ==4.5.0rc1 (pre-release with Prompt Management SDK). Updated `requirements.txt`, `Dockerfile`, and CI workflow to install from the S3 pre-release index (`https://dd-trace-py-builds.s3.amazonaws.com/96035140/index.html`).
-- Added `DD_API_KEY=${DATADOG_API_KEY}` to the app container environment in both `docker-compose.yml` and `docker-compose.yaml` (required by the prompt fetch HTTP API).
-- Updated `tests/conftest.py` with `_FakeManagedPrompt` and `_FakeAnnotationContext` stubs, plus `get_prompt()` and `annotation_context()` methods on `_FakeLLMObs`. All 139 tests pass.
-- Next step: create the "devtools-assistant" prompt in the Datadog UI (AI Observability > Prompts > New Prompt) with the system instructions and assign the "production" label.
+- Integrated Datadog Prompt Management and Prompt Tracking into the chatbot (PR #24, merged).
+- Upgraded ddtrace from >=4.4.0 to ==4.5.0rc1. Updated `requirements.txt`, `Dockerfile`, and CI workflow to install from the S3 pre-release index.
+- Added `DD_API_KEY=${DATADOG_API_KEY}` to the app container environment in both compose files.
+- Added `_FakeAnnotationContext` stub and `annotation_context()` method on `_FakeLLMObs` in conftest.py. All 139 tests pass.
 
 ### 2026-02-17T15:55:00Z
 - Fixed `sqlite3.OperationalError: fts5: syntax error near "/"` in chatbot search (PR #22, merged).

--- a/chatbot.py
+++ b/chatbot.py
@@ -24,14 +24,11 @@ _CHATBOT_MODEL = os.getenv("CHATBOT_MODEL", "gpt-4o-mini")
 _CHATBOT_MAX_TURNS = max(1, int(os.getenv("CHATBOT_MAX_TURNS", "3")))
 _MAX_TOOLS_IN_CONTEXT = int(os.getenv("CHATBOT_MAX_TOOLS", "10"))
 
-_PROMPT_ID = "devtools-assistant"
-_PROMPT_LABEL = os.getenv("CHATBOT_PROMPT_LABEL", "production")
-
 # FTS5 operator pattern to sanitize user-supplied queries
 _FTS5_OPERATORS = re.compile(r'["\*\(\)\+\-\^:/\{\}]')
 _FTS5_KEYWORDS = re.compile(r'\b(AND|OR|NOT|NEAR)\b', re.IGNORECASE)
 
-_FALLBACK_PROMPT = """\
+_SYSTEM_PROMPT = """\
 You are a helpful assistant for DevTools Scraper, a developer tools discovery platform.
 Your job is to recommend developer tools from our database based on what the user asks.
 
@@ -44,6 +41,12 @@ Guidelines:
 - Never invent tools that are not in the search results.
 - Keep the total response under 300 words.
 """
+
+_PROMPT_TRACKING = {
+    "id": "devtools-assistant",
+    "template": _SYSTEM_PROMPT,
+    "version": "1.0",
+}
 
 
 def _sanitize_fts_query(query: str) -> str:
@@ -85,44 +88,6 @@ def count_tools() -> str:
     return str(total)
 
 
-def _get_prompt() -> Any:
-    """Fetch the chatbot system prompt from Datadog Prompt Management.
-
-    Returns:
-        A ManagedPrompt backed by the Datadog-hosted prompt, or
-        a fallback-backed prompt if the fetch fails.
-    """
-    return LLMObs.get_prompt(
-        _PROMPT_ID,
-        label=_PROMPT_LABEL,
-        fallback=_FALLBACK_PROMPT,
-    )
-
-
-def _instructions_from_prompt(prompt: Any) -> str:
-    """Extract a plain instruction string from a managed prompt.
-
-    Handles both text templates (returns str) and chat templates
-    (returns list of message dicts) by pulling the system message.
-
-    Args:
-        prompt: A ManagedPrompt from LLMObs.get_prompt().
-
-    Returns:
-        The instruction string to pass to the agent.
-    """
-    rendered = prompt.format()
-    if isinstance(rendered, str):
-        return rendered
-    # Chat template: prefer the system message content.
-    for msg in rendered:
-        if isinstance(msg, dict) and msg.get("role") == "system":
-            return msg["content"]
-    if rendered and isinstance(rendered[0], dict):
-        return rendered[0].get("content", _FALLBACK_PROMPT)
-    return _FALLBACK_PROMPT
-
-
 def _collect_tools(result: Any) -> list[dict[str, Any]]:
     """Extract deduplicated tool dicts from the agent run's tool call outputs."""
     seen_ids: set[int] = set()
@@ -144,12 +109,20 @@ def _collect_tools(result: Any) -> list[dict[str, Any]]:
     return tools
 
 
+_agent = Agent(
+    name="DevToolsAssistant",
+    instructions=_SYSTEM_PROMPT,
+    model=_CHATBOT_MODEL,
+    tools=[search_tools, count_tools],
+)
+
+
 def generate_chat_response(user_message: str) -> dict[str, Any]:
     """Generate a chatbot response for a user's natural language question.
 
-    Fetches the latest prompt from Datadog Prompt Management, creates an
-    agent with those instructions, and wraps the run in an annotation
-    context for prompt tracking in LLM Observability.
+    Wraps the agent run in an ``LLMObs.annotation_context`` so that
+    the prompt template, version, and variables are tracked alongside
+    the LLM spans in Datadog LLM Observability.
 
     Args:
         user_message: The user's question (should be pre-validated by caller).
@@ -158,19 +131,9 @@ def generate_chat_response(user_message: str) -> dict[str, Any]:
         Dict with "response" (str) and "tools" (list of matched tool dicts).
     """
     try:
-        prompt = _get_prompt()
-        instructions = _instructions_from_prompt(prompt)
-
-        agent = Agent(
-            name="DevToolsAssistant",
-            instructions=instructions,
-            model=_CHATBOT_MODEL,
-            tools=[search_tools, count_tools],
-        )
-
-        with LLMObs.annotation_context(prompt=prompt.to_annotation_dict()):
+        with LLMObs.annotation_context(prompt=_PROMPT_TRACKING):
             result = Runner.run_sync(
-                agent,
+                _agent,
                 input=user_message,
                 max_turns=_CHATBOT_MAX_TURNS,
             )
@@ -185,7 +148,6 @@ def generate_chat_response(user_message: str) -> dict[str, Any]:
                 "message_length": len(user_message),
                 "tools_found": len(tools),
                 "response_length": len(response_text),
-                "prompt_version": getattr(prompt, "version", "unknown"),
             },
         )
         return {"response": response_text, "tools": tools}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,21 +25,6 @@ def stub_external_sdks():
     llmobs_module = types.ModuleType("ddtrace.llmobs")
     tracer_module = types.ModuleType("ddtrace.tracer")
 
-    class _FakeManagedPrompt:
-        """Stub for ddtrace ManagedPrompt returned by LLMObs.get_prompt()."""
-
-        def __init__(self, text: str):
-            self._text = text
-            self.id = "devtools-assistant"
-            self.version = "fallback"
-            self.label = "production"
-
-        def format(self, **kwargs):
-            return self._text
-
-        def to_annotation_dict(self, **kwargs):
-            return {"prompt_id": self.id, "version": self.version}
-
     class _FakeAnnotationContext:
         """Stub for LLMObs.annotation_context() context manager."""
 
@@ -58,12 +43,6 @@ def stub_external_sdks():
         @classmethod
         def enable(cls, *args, **kwargs):
             cls.calls.append((args, kwargs))
-
-        @classmethod
-        def get_prompt(cls, prompt_id, label=None, fallback=None):
-            """Return a fake ManagedPrompt backed by the fallback text."""
-            text = fallback if isinstance(fallback, str) else ""
-            return _FakeManagedPrompt(text)
 
         @classmethod
         def annotation_context(cls, **kwargs):


### PR DESCRIPTION
## Summary
- Fixes `AttributeError: type object 'LLMObs' has no attribute 'get_prompt'` that broke the chatbot in production after PR #24
- ddtrace 4.5.0rc1 does not include the Prompt Management API (`get_prompt`). Switches to Prompt Tracking via `annotation_context(prompt=dict)` which is available
- Restores module-level `_agent` and removes the unused `_get_prompt()`, `_instructions_from_prompt()` helpers and `_FakeManagedPrompt` test stub

## Test plan
- [x] All 139 tests pass locally
- [ ] CI passes
- [ ] Deploy and verify `/api/chat` returns a real chatbot response (not the error fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)