### PR TITLE
Use gpt-4o-mini classifier default

### DIFF
--- a/ai_classifier.py
+++ b/ai_classifier.py
@@ -46,7 +46,7 @@ if _llmobs_enabled:
 
 # Set up OpenAI client
 client = openai.OpenAI(api_key=os.getenv('OPENAI_API_KEY'))
-_OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
+_OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
 
 logger = get_logger("devtools.ai")
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"3064d20b-dfad-464c-b4dd-fe03268447e7","source":"chat","resourceId":"dcd8722e-256c-4541-a72b-01fc5bf52a6f","workflowId":"ab4c91e0-fa85-4bdd-ac08-4e7f69d021c1","codeChangeId":"ab4c91e0-fa85-4bdd-ac08-4e7f69d021c1","sourceType":"trace"} -->
PR by Bits from Trace Investigation
[View session in Datadog](https://app.datadoghq.com/code/dcd8722e-256c-4541-a72b-01fc5bf52a6f) • [View in Trace Investigation](https://app.datadoghq.com/apm/trace/69949118000000001e22f140060d78ba?spanID=12267168576822569912&trace-assistant-investigation-id=d9a2cfa7-3baf-4d58-b20a-7c785cae0f7c&trace-assistant-panel-open=true)

---

## Summary
- update the AI classifier default OpenAI model to gpt-4o-mini to reduce latency

## Testing
- `mypy ./.` (fails: missing stubs/imports in existing files)