### PR TITLE
Add Datadog Prompt Management support

### DIFF
--- a/ai_classifier.py
+++ b/ai_classifier.py
@@ -4,6 +4,7 @@ import json
 import os
 import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
 
@@ -18,6 +19,15 @@ load_dotenv(BASE_DIR / ".env")
 
 from logging_config import get_logger, logging_context
 from observability import trace_external_call
+
+# Ensure DD_API_KEY is set for ddtrace prompt management
+if not os.getenv("DD_API_KEY") and os.getenv("DATADOG_API_KEY"):
+    os.environ["DD_API_KEY"] = os.getenv("DATADOG_API_KEY")
+
+try:
+    from ddtrace.llmobs import LLMObs as _LLMObs
+except Exception:
+    _LLMObs = None
 
 # Set up OpenAI client — LLM Observability is handled by ddtrace-run at process
 # startup (DD_LLMOBS_ENABLED=1); calling LLMObs.enable() again here would
@@ -100,11 +110,168 @@ DEVTOOLS_KEYWORDS = [
 
 _DEVTOOLS_KEYWORDS_LOWER = [kw.lower() for kw in DEVTOOLS_KEYWORDS]
 
+# ---------------------------------------------------------------------------
+# Prompt Management: fallback chat templates used when Datadog prompts are
+# unavailable.  Variable placeholders use {{var}} syntax matching the Datadog
+# Prompt Management template format.
+# ---------------------------------------------------------------------------
+
+_BINARY_CLASSIFIER_FALLBACK = [
+    {
+        "role": "system",
+        "content": (
+            "You are a binary classifier for developer tools. "
+            "Respond with EXACTLY 'yes' or 'no'. If uncertain, respond 'no'."
+        ),
+    },
+    {
+        "role": "user",
+        "content": (
+            "You are a classifier that determines if software/tools are "
+            "developer tools (devtools).\n\n"
+            "Devtools include:\n"
+            "- Development tools (IDEs, text editors, debuggers)\n"
+            "- Build tools, package managers, CI/CD tools\n"
+            "- Testing frameworks, monitoring tools\n"
+            "- API tools, SDKs, libraries\n"
+            "- DevOps tools, infrastructure tools\n"
+            "- Code analysis, linting, formatting tools\n"
+            "- Database tools, deployment tools\n"
+            "- Terminal tools, CLI applications\n"
+            "- Developer productivity tools\n\n"
+            "NOT devtools:\n"
+            "- End-user applications (games, social media, productivity apps)\n"
+            "- Business software, marketing tools\n"
+            "- Consumer apps, entertainment apps\n"
+            "- E-commerce, finance apps (unless specifically for developers)\n\n"
+            "Content to classify:\n"
+            "Name: {{name}}\n"
+            "Description: {{description}}\n\n"
+            "Answer with ONLY \"yes\" or \"no\"."
+        ),
+    },
+]
+
+_BATCH_CLASSIFIER_FALLBACK = [
+    {
+        "role": "system",
+        "content": (
+            "Classify each item as devtools-related. "
+            "Respond with JSON object {\"results\": {\"<item_id>\": \"yes\"|\"no\", ...}}. "
+            "If unsure, respond with \"no\"."
+        ),
+    },
+    {
+        "role": "user",
+        "content": "{{items_json}}",
+    },
+]
+
+_CATEGORY_CLASSIFIER_FALLBACK = [
+    {
+        "role": "system",
+        "content": (
+            "You are a devtool categorizer. Respond with EXACTLY one of the "
+            "specified category names. If the tool doesn't fit, respond with 'Other'."
+        ),
+    },
+    {
+        "role": "user",
+        "content": (
+            "Classify this devtool into one of these categories:\n"
+            "- IDE/Editor: Integrated development environments, code editors\n"
+            "- CLI Tool: Command line tools, terminal applications\n"
+            "- Testing: Testing frameworks, test runners, mocking tools\n"
+            "- Build/Deploy: Build tools, deployment tools, CI/CD\n"
+            "- Monitoring/Observability: Logging, metrics, tracing, alerting\n"
+            "- Database: Database tools, ORMs, query builders\n"
+            "- API/SDK: API tools, SDKs, client libraries\n"
+            "- DevOps: Infrastructure, containerization, orchestration\n"
+            "- Code Quality: Linters, formatters, static analysis\n"
+            "- Package Manager: Dependency management, package managers\n"
+            "- Other: Anything else\n\n"
+            "Examples:\n"
+            "Name: VSCode\n"
+            "Description: A code editor for developers.\n"
+            "Category: IDE/Editor\n\n"
+            "Name: GitHub Actions\n"
+            "Description: A CI/CD automation tool for code repositories.\n"
+            "Category: Build/Deploy\n\n"
+            "Name: Postman\n"
+            "Description: API development and testing tool.\n"
+            "Category: API/SDK\n\n"
+            "Name: Datadog\n"
+            "Description: Cloud monitoring and observability platform.\n"
+            "Category: Monitoring/Observability\n\n"
+            "Name: Slack\n"
+            "Description: A team chat and collaboration app.\n"
+            "Category: Other\n\n"
+            "Name: QuickBooks\n"
+            "Description: Accounting software for small businesses.\n"
+            "Category: Other\n\n"
+            "Name: {{name}}\n"
+            "Description: {{description}}\n\n"
+            "Respond with ONLY the category name."
+        ),
+    },
+]
+
+
+class _LocalPrompt:
+    """Minimal ManagedPrompt stand-in when ddtrace is unavailable."""
+
+    def __init__(self, prompt_id, template):
+        self.id = prompt_id
+        self.version = "fallback"
+        self.label = "local"
+        self._template = template
+
+    def format(self, **variables):
+        result = []
+        for msg in self._template:
+            content = msg["content"]
+            for key, value in variables.items():
+                content = content.replace("{{" + key + "}}", str(value))
+            result.append({"role": msg["role"], "content": content})
+        return result
+
+    def to_annotation_dict(self, **variables):
+        return {
+            "id": self.id,
+            "version": self.version,
+            "template": self._template,
+            "variables": variables,
+        }
+
+
+def _get_prompt(prompt_id, fallback):
+    """Fetch a managed prompt from Datadog, falling back to local template."""
+    if _LLMObs is not None:
+        try:
+            return _LLMObs.get_prompt(prompt_id, label="production", fallback=fallback)
+        except Exception:
+            logger.warning(
+                "prompt.fetch_failed",
+                extra={"event": "prompt.fetch_failed", "prompt_id": prompt_id},
+            )
+    return _LocalPrompt(prompt_id, fallback)
+
+
+@contextmanager
+def _prompt_context(prompt, variables):
+    """Wrap a block in LLMObs.annotation_context when available."""
+    if _LLMObs is not None:
+        with _LLMObs.annotation_context(prompt=prompt.to_annotation_dict(**variables)):
+            yield
+    else:
+        yield
+
 
 def has_devtools_keywords(text: str, name: str = "") -> bool:
     """Quick keyword pre-filter to avoid unnecessary API calls."""
     combined_text = f"{name} {text}".lower()
     return any(keyword in combined_text for keyword in _DEVTOOLS_KEYWORDS_LOWER)
+
 
 def _cache_key(name: str, text: str) -> str:
     """Build a normalised cache key from a tool name and description."""
@@ -253,23 +420,17 @@ def classify_candidates(candidates: Iterable[Dict[str, str]]) -> Dict[str, bool]
             }
             for candidate in chunk
         ]
+        batch_prompt = _get_prompt("devtools-batch-classifier", _BATCH_CLASSIFIER_FALLBACK)
+        batch_variables = {"items_json": json.dumps(payload)}
+        batch_messages = batch_prompt.format(**batch_variables)
         try:
-            response = _call_openai(
-                [
-                    {
-                        "role": "system",
-                        "content": (
-                            "Classify each item as devtools-related. "
-                            "Respond with JSON object {\"results\": {\"<item_id>\": \"yes\"|\"no\", ...}}. "
-                            "If unsure, respond with \"no\"."
-                        ),
-                    },
-                    {"role": "user", "content": json.dumps(payload)},
-                ],
-                max_tokens=len(payload) * 20 + 50,
-                temperature=0.0,
-                response_format={"type": "json_object"},
-            )
+            with _prompt_context(batch_prompt, batch_variables):
+                response = _call_openai(
+                    batch_messages,
+                    max_tokens=len(payload) * 20 + 50,
+                    temperature=0.0,
+                    response_format={"type": "json_object"},
+                )
             content = response.choices[0].message.content.strip()
             data = json.loads(content)
             result_map = data.get("results", {})
@@ -331,47 +492,16 @@ def _classify_single(name: str, text: str) -> bool:
         )
         return is_devtools_related_fallback(text)
 
-    prompt = f"""
-    You are a classifier that determines if software/tools are developer tools (devtools).
-
-    Devtools include:
-    - Development tools (IDEs, text editors, debuggers)
-    - Build tools, package managers, CI/CD tools
-    - Testing frameworks, monitoring tools
-    - API tools, SDKs, libraries
-    - DevOps tools, infrastructure tools
-    - Code analysis, linting, formatting tools
-    - Database tools, deployment tools
-    - Terminal tools, CLI applications
-    - Developer productivity tools
-
-    NOT devtools:
-    - End-user applications (games, social media, productivity apps)
-    - Business software, marketing tools
-    - Consumer apps, entertainment apps
-    - E-commerce, finance apps (unless specifically for developers)
-
-    Content to classify:
-    Name: {name}
-    Description: {text}
-
-    Answer with ONLY "yes" or "no".
-    """
+    prompt = _get_prompt("devtools-binary-classifier", _BINARY_CLASSIFIER_FALLBACK)
+    variables = {"name": name, "description": text}
+    messages = prompt.format(**variables)
     try:
-        response = _call_openai(
-            [
-                {
-                    "role": "system",
-                    "content": (
-                        "You are a binary classifier for developer tools. "
-                        "Respond with EXACTLY 'yes' or 'no'. If uncertain, respond 'no'."
-                    ),
-                },
-                {"role": "user", "content": prompt},
-            ],
-            max_tokens=5,
-            temperature=0.0,
-        )
+        with _prompt_context(prompt, variables):
+            response = _call_openai(
+                messages,
+                max_tokens=5,
+                temperature=0.0,
+            )
         answer = response.choices[0].message.content.strip().lower()
         if answer not in {"yes", "no"}:
             logger.warning(
@@ -406,6 +536,7 @@ def is_devtools_related_ai(text: str, name: str = "") -> bool:
     _cache_set(_classification_cache, key, result)
     return result
 
+
 def is_devtools_related_fallback(text: str) -> bool:
     """Fallback keyword-based classifier when AI is unavailable."""
     text_lower = text.lower()
@@ -425,66 +556,17 @@ def get_devtools_category(text: str, name: str = "") -> Optional[str]:
     if cached is not None:
         return cached
     
-    prompt = f"""
-    Classify this devtool into one of these categories:
-    - IDE/Editor: Integrated development environments, code editors
-    - CLI Tool: Command line tools, terminal applications
-    - Testing: Testing frameworks, test runners, mocking tools
-    - Build/Deploy: Build tools, deployment tools, CI/CD
-    - Monitoring/Observability: Logging, metrics, tracing, alerting
-    - Database: Database tools, ORMs, query builders
-    - API/SDK: API tools, SDKs, client libraries
-    - DevOps: Infrastructure, containerization, orchestration
-    - Code Quality: Linters, formatters, static analysis
-    - Package Manager: Dependency management, package managers
-    - Other: Anything else
-
-    Examples:
-    Name: VSCode
-    Description: A code editor for developers.
-    Category: IDE/Editor
-
-    Name: GitHub Actions
-    Description: A CI/CD automation tool for code repositories.
-    Category: Build/Deploy
-
-    Name: Postman
-    Description: API development and testing tool.
-    Category: API/SDK
-
-    Name: Datadog
-    Description: Cloud monitoring and observability platform.
-    Category: Monitoring/Observability
-
-    Name: Slack
-    Description: A team chat and collaboration app.
-    Category: Other
-
-    Name: QuickBooks
-    Description: Accounting software for small businesses.
-    Category: Other
-
-    Name: {name}
-    Description: {text}
-
-    Respond with ONLY the category name.
-    """
+    prompt = _get_prompt("devtools-category-classifier", _CATEGORY_CLASSIFIER_FALLBACK)
+    variables = {"name": name, "description": text}
+    messages = prompt.format(**variables)
 
     try:
-        response = _call_openai(
-            [
-                {
-                    "role": "system",
-                    "content": (
-                        "You are a devtool categorizer. Respond with EXACTLY one of the specified category names. "
-                        "If the tool doesn't fit, respond with 'Other'."
-                    ),
-                },
-                {"role": "user", "content": prompt},
-            ],
-            max_tokens=15,
-            temperature=0.0,
-        )
+        with _prompt_context(prompt, variables):
+            response = _call_openai(
+                messages,
+                max_tokens=15,
+                temperature=0.0,
+            )
 
         category = response.choices[0].message.content.strip()
         _cache_set(_category_cache, key, category)

--- a/chatbot.py
+++ b/chatbot.py
@@ -49,6 +49,17 @@ _PROMPT_TRACKING = {
 }
 
 
+def _get_prompt_annotation():
+    """Fetch managed prompt for annotation tracking, falling back to static dict."""
+    try:
+        prompt = LLMObs.get_prompt(
+            "devtools-assistant", label="production", fallback=_SYSTEM_PROMPT,
+        )
+        return prompt.to_annotation_dict()
+    except Exception:
+        return _PROMPT_TRACKING
+
+
 def _sanitize_fts_query(query: str) -> str:
     """Strip FTS5 operators from a query string to prevent injection."""
     cleaned = _FTS5_OPERATORS.sub(" ", query)
@@ -131,7 +142,7 @@ def generate_chat_response(user_message: str) -> dict[str, Any]:
         Dict with "response" (str) and "tools" (list of matched tool dicts).
     """
     try:
-        with LLMObs.annotation_context(prompt=_PROMPT_TRACKING):
+        with LLMObs.annotation_context(prompt=_get_prompt_annotation()):
             result = Runner.run_sync(
                 _agent,
                 input=user_message,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,39 @@ def stub_external_sdks():
         def __exit__(self, exc_type, exc_val, exc_tb):
             return False
 
+    class _FakeManagedPrompt:
+        """Stub for ManagedPrompt returned by LLMObs.get_prompt()."""
+
+        def __init__(self, prompt_id, template, label=None):
+            self.id = prompt_id
+            self.version = "test"
+            self.label = label or "production"
+            self._template = template
+
+        def format(self, **variables):
+            if isinstance(self._template, str):
+                result = self._template
+                for key, value in variables.items():
+                    result = result.replace("{{" + key + "}}", str(value))
+                return result
+            if isinstance(self._template, list):
+                result = []
+                for msg in self._template:
+                    content = msg["content"]
+                    for key, value in variables.items():
+                        content = content.replace("{{" + key + "}}", str(value))
+                    result.append({"role": msg["role"], "content": content})
+                return result
+            return self._template
+
+        def to_annotation_dict(self, **variables):
+            return {
+                "id": self.id,
+                "version": self.version,
+                "template": self._template,
+                "variables": variables,
+            }
+
     class _FakeLLMObs:
         calls = []
 
@@ -48,6 +81,18 @@ def stub_external_sdks():
         def annotation_context(cls, **kwargs):
             """Return a no-op context manager."""
             return _FakeAnnotationContext(**kwargs)
+
+        @classmethod
+        def get_prompt(cls, prompt_id, label=None, fallback=None):
+            return _FakeManagedPrompt(prompt_id, fallback, label=label)
+
+        @classmethod
+        def clear_prompt_cache(cls, **kwargs):
+            pass
+
+        @classmethod
+        def refresh_prompt(cls, prompt_id, label=None):
+            return _FakeManagedPrompt(prompt_id, [], label=label)
 
     class _FakeSpan:
         def __enter__(self):

--- a/tests/test_prompt_management.py
+++ b/tests/test_prompt_management.py
@@ -1,0 +1,129 @@
+"""Tests for Datadog Prompt Management integration.
+
+These tests verify:
+1. The LLMObs stub supports get_prompt/clear_prompt_cache/refresh_prompt
+2. ai_classifier uses managed prompts instead of hardcoded f-strings
+3. chatbot uses managed prompts for annotation tracking
+"""
+
+import types
+
+import pytest
+
+
+def _fake_openai_response(content):
+    """Build a minimal OpenAI-shaped response with the given content string."""
+    return types.SimpleNamespace(
+        choices=[types.SimpleNamespace(message=types.SimpleNamespace(content=content))]
+    )
+
+
+def _spy_get_prompt(classifier, monkeypatch):
+    """Patch _get_prompt on classifier and return the list of captured prompt IDs."""
+    prompt_ids = []
+    orig = classifier._get_prompt
+
+    def spy(pid, fb):
+        prompt_ids.append(pid)
+        return orig(pid, fb)
+
+    monkeypatch.setattr(classifier, "_get_prompt", spy)
+    return prompt_ids
+
+
+class TestLLMObsPromptStubs:
+    """Tests that the LLMObs test stub supports prompt management methods."""
+
+    def test_get_prompt_returns_managed_prompt(self):
+        from ddtrace.llmobs import LLMObs
+
+        fallback = [{"role": "user", "content": "Hello {{name}}"}]
+        prompt = LLMObs.get_prompt("test-id", label="production", fallback=fallback)
+
+        assert prompt.id == "test-id"
+        assert prompt.label == "production"
+        assert hasattr(prompt, "format")
+        assert hasattr(prompt, "to_annotation_dict")
+
+    def test_managed_prompt_format_replaces_variables(self):
+        from ddtrace.llmobs import LLMObs
+
+        prompt = LLMObs.get_prompt(
+            "test-id",
+            fallback=[
+                {"role": "system", "content": "Be helpful."},
+                {"role": "user", "content": "Name: {{name}}, Desc: {{description}}"},
+            ],
+        )
+        messages = prompt.format(name="MyTool", description="A dev tool")
+        assert messages[0]["content"] == "Be helpful."
+        assert "MyTool" in messages[1]["content"]
+        assert "A dev tool" in messages[1]["content"]
+
+    def test_managed_prompt_format_string_fallback(self):
+        from ddtrace.llmobs import LLMObs
+
+        prompt = LLMObs.get_prompt("t", fallback="Hello {{name}}")
+        assert prompt.format(name="World") == "Hello World"
+
+    def test_to_annotation_dict_structure(self):
+        from ddtrace.llmobs import LLMObs
+
+        fallback = [{"role": "user", "content": "{{q}}"}]
+        prompt = LLMObs.get_prompt("p", label="production", fallback=fallback)
+        ann = prompt.to_annotation_dict(q="test")
+        assert ann["id"] == "p"
+        assert "version" in ann
+        assert ann["variables"] == {"q": "test"}
+
+    def test_clear_prompt_cache_noop(self):
+        from ddtrace.llmobs import LLMObs
+
+        LLMObs.clear_prompt_cache()
+
+    def test_refresh_prompt_returns_prompt(self):
+        from ddtrace.llmobs import LLMObs
+
+        prompt = LLMObs.refresh_prompt("pid", label="production")
+        assert prompt.id == "pid"
+
+
+class TestClassifierPromptManagement:
+    """Tests that ai_classifier uses _get_prompt for managed prompts."""
+
+    def test_classify_single_calls_get_prompt(self, reset_ai_classifier, monkeypatch):
+        classifier = reset_ai_classifier
+        monkeypatch.setenv("OPENAI_API_KEY", "present")
+        classifier.client.chat.completions.create = lambda *a, **kw: _fake_openai_response("yes")
+
+        prompt_ids = _spy_get_prompt(classifier, monkeypatch)
+        assert classifier._classify_single("DevCLI", "developer CLI tool") is True
+        assert "devtools-binary-classifier" in prompt_ids
+
+    def test_get_devtools_category_calls_get_prompt(self, reset_ai_classifier, monkeypatch):
+        classifier = reset_ai_classifier
+        monkeypatch.setenv("OPENAI_API_KEY", "present")
+        classifier.client.chat.completions.create = lambda *a, **kw: _fake_openai_response("CLI Tool")
+
+        prompt_ids = _spy_get_prompt(classifier, monkeypatch)
+        assert classifier.get_devtools_category("CLI utils", "MyCLI") == "CLI Tool"
+        assert "devtools-category-classifier" in prompt_ids
+
+    def test_get_prompt_falls_back_when_llmobs_none(self, reset_ai_classifier, monkeypatch):
+        classifier = reset_ai_classifier
+        monkeypatch.setattr(classifier, "_LLMObs", None)
+
+        prompt = classifier._get_prompt("test", [
+            {"role": "user", "content": "Hello {{name}}"},
+        ])
+        assert prompt.id == "test"
+        assert prompt.version == "fallback"
+        messages = prompt.format(name="World")
+        assert messages[0]["content"] == "Hello World"
+
+    def test_fallback_templates_exist(self, reset_ai_classifier):
+        classifier = reset_ai_classifier
+        assert isinstance(classifier._BINARY_CLASSIFIER_FALLBACK, list)
+        assert isinstance(classifier._BATCH_CLASSIFIER_FALLBACK, list)
+        assert isinstance(classifier._CATEGORY_CLASSIFIER_FALLBACK, list)
+        assert len(classifier._BINARY_CLASSIFIER_FALLBACK) >= 2


### PR DESCRIPTION
## Summary
- Integrates Datadog Prompt Management (`LLMObs.get_prompt()`) into all 4 LLM prompts across `ai_classifier.py` and `chatbot.py`
- Current hardcoded prompts become fallback templates -- app works identically without UI prompts configured
- Adds `annotation_context` to all OpenAI calls in `ai_classifier.py` for prompt version tracking in traces
- Maps `DATADOG_API_KEY` to `DD_API_KEY` automatically for prompt management SDK compatibility

## Test plan
- [x] All 161 tests pass (151 existing + 10 new prompt management tests)
- [x] New tests cover: managed prompt fetch, fallback when LLMObs unavailable, `_LocalPrompt` formatting, annotation dict structure
- [ ] Manual: create prompts in Datadog UI (devtools-binary-classifier, devtools-batch-classifier, devtools-category-classifier, devtools-assistant) and verify they are fetched at runtime
- [ ] Manual: verify annotation_context shows prompt version in Datadog LLM Observability traces

Generated with [Claude Code](https://claude.com/claude-code)