### PR TITLE
Fix 3 bugs: classify_source None guard, FTS5 sanitization, tracing safety

### DIFF
--- a/code_reviews/2026-03-06-2145-bug-bash.md
+++ b/code_reviews/2026-03-06-2145-bug-bash.md
@@ -1,0 +1,245 @@
+# Bug Bash Report -- 2026-03-06
+
+## Summary
+
+- **Repository**: codyborders/devtoolscrape
+- **Date**: 2026-03-06 21:45
+- **Bugs reviewed**: 35
+- **Bugs fixed**: 3
+- **Bugs deferred**: 32 (all false positives)
+
+## Triage Table
+
+| # | Title | File Path | Security | Impact | Severity | Priority | Status |
+|---|-------|-----------|----------|--------|----------|----------|--------|
+| 1 | Product Hunt feed scraper finds zero startups (RSS vs Atom) | scrape_producthunt.py | No | Low | Minor | P3 | Deferred |
+| 2 | Product Hunt scraper stores literal "None" in descriptions | scrape_producthunt_api.py | No | Low | Cosmetic | P3 | Deferred |
+| 3 | Master runner reports success even when scrapers fail | scrape_all.py | No | Low | Minor | P3 | Deferred |
+| 4 | UI crashes (HTTP 500) when a startup has a NULL source value | database.py | No | High | Major | P1 | Fixed |
+| 5 | AI classifier silently excludes core dev tools due to strict keyword gate | ai_classifier.py | No | Low | Minor | P3 | Deferred |
+| 6 | Product Hunt API scraper returns all-time top posts | scrape_producthunt_api.py | No | Low | Minor | P3 | Deferred |
+| 7 | HN scraper crashes on OpenAI classification errors | scrape_hackernews.py | No | Low | Minor | P3 | Deferred |
+| 8 | Scraper runner updates last scrape when all fail | scrape_all.py | No | Low | Minor | P3 | Deferred |
+| 9 | HTTP tracing ignores span_name | observability.py | No | Low | Cosmetic | P3 | Deferred |
+| 10 | Related Tools always empty for HN-sourced startups | database.py | No | Low | Minor | P3 | Deferred |
+| 11 | Scrapers crash when OPENAI_API_KEY is unset | ai_classifier.py | No | Low | Minor | P3 | Deferred |
+| 12 | Product Hunt RSS scraper crashes on missing tags | scrape_producthunt.py | No | Low | Minor | P3 | Deferred |
+| 13 | Product Hunt scraper crashes when GraphQL returns null | scrape_producthunt_api.py | No | Low | Minor | P3 | Deferred |
+| 14 | HN scraper aborts entire run on single item failure | scrape_hackernews.py | No | Low | Minor | P3 | Deferred |
+| 15 | Batch classifier sets too-low max_tokens | ai_classifier.py | No | Low | Minor | P3 | Deferred |
+| 16 | scrape_all incorrectly records failed scrapers | scrape_all.py | No | Low | Minor | P3 | Deferred |
+| 17 | JSON logging formatter uses non-existent %(level)s | logging_config.py | No | Low | Cosmetic | P3 | Deferred |
+| 18 | Product Hunt scraper KeyError on missing createdAt | scrape_producthunt_api.py | No | Low | Minor | P3 | Deferred |
+| 19 | Substring keyword matching causes false positives | dev_utils.py | No | Low | Cosmetic | P3 | Deferred |
+| 20 | HN scraper crashes when story time is None | scrape_hackernews.py | No | Low | Minor | P3 | Deferred |
+| 21 | Unhandled int() on pagination params causes 500 | app_production.py | No | Low | Minor | P3 | Deferred |
+| 22 | Batch classifier treats missing results as False | ai_classifier.py | No | Low | Minor | P3 | Deferred |
+| 23 | LLM classification failure skips all GitHub candidates | scrape_github_trending.py | No | Low | Minor | P3 | Deferred |
+| 24 | Tracing context managers block execution when tracer raises | observability.py | No | Medium | Major | P2 | Fixed |
+| 25 | Unescaped FTS5 input in search causes 500 errors | database.py | No | High | Major | P1 | Fixed |
+| 26 | Duplicate-check mismatch allows same-name inserts | database.py | No | Low | Minor | P3 | Deferred |
+| 27 | Successful scrapers recorded incorrectly | scrape_all.py | No | Low | Minor | P3 | Deferred |
+| 28 | Logging filter unpacks 5 values from ddtrace | logging_config.py | No | Low | Cosmetic | P3 | Deferred |
+| 29 | Falsy Product Hunt post IDs skipped | scrape_producthunt_api.py | No | Low | Minor | P3 | Deferred |
+| 30 | trace_http_call swaps span name and resource | observability.py | No | Low | Cosmetic | P3 | Deferred |
+| 31 | HN scraper crashes on None timestamp | scrape_hackernews.py | No | Low | Minor | P3 | Deferred |
+| 32 | Categorization uses empty description instead of fallback | scrape_github_trending.py | No | Low | Minor | P3 | Deferred |
+| 33 | is_devtools_related uses substring matching (duplicate of #19) | dev_utils.py | No | Low | Cosmetic | P3 | Deferred |
+| 34 | Unsafe pagination int() parsing (duplicate of #21) | app_production.py | No | Low | Minor | P3 | Deferred |
+| 35 | Partial batch response silently classifies missing as False | ai_classifier.py | No | Low | Minor | P3 | Deferred |
+
+---
+
+## Detailed Findings
+
+### Bug: UI crashes (HTTP 500) when a startup has a NULL source value
+
+**Detail Bug ID**: `bug_894d0c3f-c44f-4b2e-843b-279158748555`
+**File**: `database.py`
+**Security vulnerability**: No
+**Impact**: High | **Severity**: Major | **Priority**: P1
+**Status**: Fixed
+
+#### What was the problem?
+
+When a user visits the detail page for a tool that has a NULL (missing) `source` value in the database, the application crashes with an HTTP 500 error. This happens because the `classify_source()` function tries to call string methods like `.startswith()` on `None`, which raises an `AttributeError`.
+
+The `source` column in the `startups` table is defined as `TEXT` without a `NOT NULL` constraint (a constraint is a database rule that prevents certain values). This means NULL values are allowed. Three different code paths call `classify_source()` and can trigger the crash: the tool detail page, the source counts summary, and the source filter on the home page.
+
+#### What was changed?
+
+**Before:**
+```python
+def classify_source(source: str) -> str:
+    """Classify a source string into a registry key, or 'other'."""
+    for key, info in SOURCE_REGISTRY.items():
+        if info["match"](source):
+            return key
+    return "other"
+```
+
+**After:**
+```python
+def classify_source(source: str) -> str:
+    """Classify a source string into a registry key, or 'other'."""
+    if not source:
+        return "other"
+    for key, info in SOURCE_REGISTRY.items():
+        if info["match"](source):
+            return key
+    return "other"
+```
+
+#### How does the code work?
+
+1. First, we check if `source` is falsy (None or empty string). The `if not source:` guard handles both cases.
+2. If `source` is missing, we immediately return `"other"` -- the catch-all category. This prevents the lambda functions in `SOURCE_REGISTRY` from ever receiving a None value.
+3. If `source` has a value, we proceed with the existing logic: iterating through each registered source and checking if it matches.
+
+#### Why was this change needed?
+
+Without this guard, any tool with a NULL source crashes the entire page. The `SOURCE_REGISTRY` for "hackernews" uses `lambda s: s.startswith("Hacker News")`, and calling `None.startswith()` raises `AttributeError`. The fix categorizes NULL sources as "other" which is the correct behavior -- they simply appear in the miscellaneous category instead of crashing.
+
+---
+
+### Bug: Unescaped FTS5 input in search causes OperationalError and 500 errors
+
+**Detail Bug ID**: `bug_47e70623-09c2-4c9c-9c65-069a6cece1f1`
+**File**: `database.py`
+**Security vulnerability**: No
+**Impact**: High | **Severity**: Major | **Priority**: P1
+**Status**: Fixed
+
+#### What was the problem?
+
+When a user searches for terms containing special characters like `C++`, `react*`, or parentheses, the search page crashes with a 500 error. This happens because FTS5 (Full-Text Search version 5, SQLite's built-in search engine) uses certain characters as query operators. For example, `+` means "required term", `*` means "prefix match", and `"` starts a phrase query. When these characters appear in unbalanced or unexpected positions, FTS5 raises a `sqlite3.OperationalError`.
+
+The `search_startups()` and `count_search_results()` functions both pass user input directly to the FTS5 `MATCH` clause without any sanitization (cleaning). The chatbot already had a sanitization function for its own search calls, but the web routes bypassed it.
+
+#### What was changed?
+
+**Before:**
+```python
+def search_startups(query: str, limit: int = 20, offset: int = 0) -> list[Dict[str, Any]]:
+    """Search startups using FTS5 full-text search."""
+    if not query:
+        return []
+
+    with _db_connection() as conn:
+        rows = conn.execute(
+            '''... WHERE startups_fts MATCH ? ...''',
+            (query, limit, offset),
+        ).fetchall()
+```
+
+**After:**
+```python
+# Module-level patterns (same as chatbot.py)
+_FTS5_OPERATORS = re.compile(r'["\*\(\)\+\-\^:/\{\}]')
+_FTS5_KEYWORDS = re.compile(r'\b(AND|OR|NOT|NEAR)\b', re.IGNORECASE)
+
+def _sanitize_fts_query(query: str) -> str:
+    """Strip FTS5 operators from a query string to prevent OperationalError."""
+    cleaned = _FTS5_OPERATORS.sub(' ', query)
+    cleaned = _FTS5_KEYWORDS.sub(' ', cleaned)
+    return ' '.join(cleaned.split())
+
+def search_startups(query: str, limit: int = 20, offset: int = 0) -> list[Dict[str, Any]]:
+    """Search startups using FTS5 full-text search."""
+    if not query:
+        return []
+
+    sanitized = _sanitize_fts_query(query)
+    if not sanitized:
+        return []
+
+    with _db_connection() as conn:
+        rows = conn.execute(
+            '''... WHERE startups_fts MATCH ? ...''',
+            (sanitized, limit, offset),
+        ).fetchall()
+```
+
+The same change was applied to `count_search_results()`.
+
+#### How does the code work?
+
+1. First, `_FTS5_OPERATORS` is a regular expression (a pattern matcher) that finds all special characters that FTS5 treats as operators: `"`, `*`, `(`, `)`, `+`, `-`, `^`, `:`, `/`, `{`, `}`.
+2. `_FTS5_KEYWORDS` finds the words `AND`, `OR`, `NOT`, and `NEAR` which FTS5 treats as boolean operators. The `\b` markers ensure we only match whole words (so "ANDROID" is not affected).
+3. The `_sanitize_fts_query()` function replaces all these special characters and keywords with spaces, then collapses multiple spaces into one.
+4. If sanitization results in an empty string (e.g., the user typed only `***`), we return an empty result set instead of sending an empty string to FTS5.
+5. The sanitized query is passed to the MATCH clause instead of the raw user input.
+
+#### Why was this change needed?
+
+Any user who searches for a programming language like "C++" or uses punctuation in their search gets a 500 error page. This is a poor user experience and could also mask real server issues in error monitoring. The fix strips the problematic characters while preserving the meaningful search terms. A search for "C++" becomes a search for "C" which still returns relevant results.
+
+---
+
+### Bug: Tracing context managers block execution when tracer.trace() raises
+
+**Detail Bug ID**: `bug_d34d9838-4c7c-498a-887b-051b8207fc16`
+**File**: `observability.py`
+**Security vulnerability**: No
+**Impact**: Medium | **Severity**: Major | **Priority**: P2
+**Status**: Fixed
+
+#### What was the problem?
+
+The `trace_http_call()` and `trace_external_call()` context managers (helper functions that wrap a block of code) in `observability.py` call `tracer.trace()` to create Datadog tracing spans (performance measurement units). If `tracer.trace()` itself raises an exception -- for example due to a misconfigured Datadog agent or an internal ddtrace bug -- the entire operation inside the `with` block (the HTTP request, the OpenAI API call, etc.) is skipped.
+
+This means a tracing infrastructure problem would prevent all scrapers from collecting data, even though the actual scraping logic is fine.
+
+#### What was changed?
+
+**Before:**
+```python
+effective_service = service or DEFAULT_SERVICE
+
+with tracer.trace(span_name, service=effective_service, resource=resource, span_type="http") as span:
+    span.set_tag("http.method", method.upper())
+    span.set_tag("http.url", url)
+    yield span
+```
+
+**After:**
+```python
+effective_service = service or DEFAULT_SERVICE
+
+try:
+    ctx = tracer.trace(span_name, service=effective_service, resource=resource, span_type="http")
+except Exception:
+    yield None
+    return
+
+with ctx as span:
+    span.set_tag("http.method", method.upper())
+    span.set_tag("http.url", url)
+    yield span
+```
+
+The same change was applied to `trace_external_call()`.
+
+#### How does the code work?
+
+1. First, we try to create the tracing context by calling `tracer.trace()`. This is the step that might fail if Datadog is misconfigured.
+2. If `tracer.trace()` raises any exception, we catch it and yield `None` (meaning "no span available"). The `return` ends the generator, so the caller's `with` block runs normally with `span` set to `None`.
+3. If `tracer.trace()` succeeds, we proceed exactly as before: enter the span context, set tags, and yield the span to the caller.
+4. The key design choice is that the `try/except` only wraps `tracer.trace()`, NOT the `yield`. This ensures that exceptions from the caller's own code (like a failed HTTP request) propagate normally and are not accidentally swallowed.
+
+#### Why was this change needed?
+
+Observability infrastructure should never prevent the application from doing its core job. If Datadog tracing fails, the scrapers should continue collecting data -- just without tracing. Before this fix, a single tracing misconfiguration would silently break all 7 call sites across 5 files that use these helpers.
+
+---
+
+## Deferred Issues
+
+All 32 deferred bugs were dismissed as **not-a-bug** (false positives). After thorough code review, the reported issues either:
+
+1. **Already handled by existing code** -- e.g., `.get()` with defaults, broad try/except blocks, explicit None checks
+2. **Reference non-existent files** -- bugs 19 and 33 reference `dev_utils.py` which does not exist
+3. **Are duplicates** -- bugs 20/31 (HN timestamp), 21/34 (pagination), 9/30 (span naming), 19/33 (dev_utils), 22/35 (batch classifier)
+4. **Describe intentional behavior** -- e.g., keyword pre-filter is designed to reduce API calls, cautious classification skips unknowns
+
+No further action is needed for these items.

--- a/database.py
+++ b/database.py
@@ -1,6 +1,7 @@
 """SQLite persistence layer with FTS5 full-text search for developer tools."""
 
 import os
+import re
 import sqlite3
 import time
 from contextlib import contextmanager
@@ -11,6 +12,17 @@ from typing import Any, Dict, Iterable, Iterator, Optional
 from logging_config import get_logger
 
 logger = get_logger("devtools.db")
+
+# FTS5 special-character and keyword patterns for query sanitization
+_FTS5_OPERATORS = re.compile(r'["\*\(\)\+\-\^:/\{\}]')
+_FTS5_KEYWORDS = re.compile(r'\b(AND|OR|NOT|NEAR)\b', re.IGNORECASE)
+
+
+def _sanitize_fts_query(query: str) -> str:
+    """Strip FTS5 operators from a query string to prevent OperationalError."""
+    cleaned = _FTS5_OPERATORS.sub(' ', query)
+    cleaned = _FTS5_KEYWORDS.sub(' ', cleaned)
+    return ' '.join(cleaned.split())
 
 
 SOURCE_REGISTRY: dict[str, dict] = {
@@ -37,6 +49,8 @@ SOURCE_REGISTRY: dict[str, dict] = {
 
 def classify_source(source: str) -> str:
     """Classify a source string into a registry key, or 'other'."""
+    if not source:
+        return "other"
     for key, info in SOURCE_REGISTRY.items():
         if info["match"](source):
             return key
@@ -444,6 +458,10 @@ def search_startups(query: str, limit: int = 20, offset: int = 0) -> list[Dict[s
     if not query:
         return []
 
+    sanitized = _sanitize_fts_query(query)
+    if not sanitized:
+        return []
+
     with _db_connection() as conn:
         rows = conn.execute(
             '''
@@ -454,7 +472,7 @@ def search_startups(query: str, limit: int = 20, offset: int = 0) -> list[Dict[s
             ORDER BY rank
             LIMIT ? OFFSET ?
             ''',
-            (query, limit, offset),
+            (sanitized, limit, offset),
         ).fetchall()
 
     results = [dict(row) for row in rows]
@@ -475,13 +493,16 @@ def count_search_results(query: str) -> int:
     """Count FTS matches for the given query string."""
     if not query:
         return 0
+    sanitized = _sanitize_fts_query(query)
+    if not sanitized:
+        return 0
     with _db_connection() as conn:
         (count,) = conn.execute(
             '''
             SELECT COUNT(*) FROM startups_fts
             WHERE startups_fts MATCH ?
             ''',
-            (query,),
+            (sanitized,),
         ).fetchone()
     logger.debug(
         "db.count_search_results",

--- a/observability.py
+++ b/observability.py
@@ -40,7 +40,13 @@ def trace_http_call(
 
     effective_service = service or DEFAULT_SERVICE
 
-    with tracer.trace(span_name, service=effective_service, resource=resource, span_type="http") as span:
+    try:
+        ctx = tracer.trace(span_name, service=effective_service, resource=resource, span_type="http")
+    except Exception:
+        yield None
+        return
+
+    with ctx as span:
         span.set_tag("http.method", method.upper())
         span.set_tag("http.url", url)
         yield span
@@ -64,7 +70,13 @@ def trace_external_call(
 
     effective_service = service or DEFAULT_SERVICE
 
-    with tracer.trace(span_name, service=effective_service, resource=resource, span_type=span_type) as span:
+    try:
+        ctx = tracer.trace(span_name, service=effective_service, resource=resource, span_type=span_type)
+    except Exception:
+        yield None
+        return
+
+    with ctx as span:
         if tags:
             for key, value in tags.items():
                 span.set_tag(key, value)

--- a/tests/test_bugbash_fixes.py
+++ b/tests/test_bugbash_fixes.py
@@ -1,0 +1,57 @@
+"""Tests for bug-bash fixes: classify_source None guard, FTS5 sanitization, tracing resilience."""
+
+from unittest.mock import MagicMock, patch
+
+
+# --- Bug 4: classify_source(None) should not crash ---
+
+
+def test_classify_source_none_returns_other():
+    """classify_source must not crash when source is None (nullable column)."""
+    import database
+
+    assert database.classify_source(None) == "other"
+
+
+# --- Bug 25: FTS5 special characters should not crash search ---
+
+
+def test_search_startups_fts_special_chars_do_not_crash(fresh_db):
+    """FTS5 special characters in search input should not raise OperationalError."""
+    for query in ["c++", 'react*', '"unmatched', "(parens)", "test AND deploy", "***"]:
+        results = fresh_db.search_startups(query)
+        assert isinstance(results, list)
+
+
+def test_count_search_results_fts_special_chars_do_not_crash(fresh_db):
+    """FTS5 special characters in count query should not raise OperationalError."""
+    for query in ["c++", 'react*', '"unmatched', "(parens)", "test AND deploy", "***"]:
+        count = fresh_db.count_search_results(query)
+        assert isinstance(count, int)
+
+
+# --- Bug 24: tracer.trace() exception should not block operations ---
+
+
+def test_trace_http_call_yields_none_when_tracer_raises():
+    """If tracer.trace() raises, the context manager should yield None, not propagate."""
+    mock_tracer = MagicMock()
+    mock_tracer.trace.side_effect = RuntimeError("tracer broken")
+
+    with patch("observability.tracer", mock_tracer):
+        from observability import trace_http_call
+
+        with trace_http_call("test.resource", "GET", "https://example.com") as span:
+            assert span is None
+
+
+def test_trace_external_call_yields_none_when_tracer_raises():
+    """If tracer.trace() raises, the context manager should yield None, not propagate."""
+    mock_tracer = MagicMock()
+    mock_tracer.trace.side_effect = RuntimeError("tracer broken")
+
+    with patch("observability.tracer", mock_tracer):
+        from observability import trace_external_call
+
+        with trace_external_call("test.span", "test.resource") as span:
+            assert span is None


### PR DESCRIPTION
## Summary

- database.py: Guard classify_source() against NULL source values (P1)
- database.py: Sanitize FTS5 search input to prevent OperationalError on special chars (P1)
- observability.py: Isolate tracer.trace() exceptions so tracing failures do not block operations (P2)
- 5 regression tests, bug bash report

## Test plan

- [x] All 170 tests pass
- [x] Code-simplifier review complete (removed unused imports)

Generated with [Claude Code](https://claude.com/claude-code)