### PR TITLE
Fix openai version pin to unblock CI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 flask>=3.0.0,<4.0.0
 requests>=2.32.4,<3.0.0
 beautifulsoup4>=4.13.4,<5.0.0
-openai>=1.66.0,<2.0.0
+openai>=2.9.0,<3.0.0
 openai-agents>=0.7.0,<0.8.0
 python-dotenv>=1.1.1,<2.0.0
 lxml>=6.0.0,<7.0.0


### PR DESCRIPTION
## Summary

- Widen openai pin from `>=1.66.0,<2.0.0` to `>=2.9.0,<3.0.0`
- The old upper bound conflicted with `openai-agents>=0.7.0` which requires `openai>=2.9.0`
- This has broken every CI run since PR #43 -- pip cannot resolve dependencies, so tests/build/deploy all skip
- The codebase already uses `client.responses.create()` (Responses API, v2+), so the old pin was stale

## Test plan

- [x] CI should now pass Install dependencies step
- [x] Build and deploy jobs should run, updating the Datadog version tag

Generated with [Claude Code](https://claude.com/claude-code)