### PR TITLE
Fix _FakeTracer stub for Datadog Test Visibility

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,7 +104,13 @@ def stub_external_sdks():
         def set_tag(self, *args, **kwargs):
             return None
 
+    class _FakeContextProvider:
+        def activate(self, *args, **kwargs):
+            pass
+
     class _FakeTracer:
+        context_provider = _FakeContextProvider()
+
         def trace(self, *args, **kwargs):
             return _FakeSpan()
 


### PR DESCRIPTION
## Summary

- Add `context_provider` attribute to `_FakeTracer` in conftest.py
- The Datadog Test Visibility plugin calls `ddtrace.tracer.context_provider.activate(None)` during test teardown, which crashes with `AttributeError` when it hits our stub
- This was the remaining CI blocker after the openai version pin fix (#47)

## Test plan

- [x] 156 tests pass locally
- [x] CI should now pass the Run tests step

Generated with [Claude Code](https://claude.com/claude-code)