### PR TITLE
Bump max_output_tokens to 16 to meet OpenAI minimum

### DIFF
--- a/ai_classifier.py
+++ b/ai_classifier.py
@@ -544,7 +544,7 @@ def _classify_single(
         with _prompt_context(prompt, variables):
             response = _call_openai(
                 messages,
-                max_output_tokens=5,
+                max_output_tokens=16,
                 temperature=0.0,
             )
         answer = response.output_text.strip().lower()
@@ -606,7 +606,7 @@ def get_devtools_category(text: str, name: str = "") -> str | None:
         with _prompt_context(prompt, variables):
             response = _call_openai(
                 messages,
-                max_output_tokens=15,
+                max_output_tokens=16,
                 temperature=0.0,
             )
 


### PR DESCRIPTION
## Summary

- OpenAI now enforces max_output_tokens >= 16
- Two call sites in ai_classifier.py were below the minimum: 5 and 15
- Both bumped to 16 (the minimum needed for their short responses)

## Test plan

- [x] 18 classifier tests pass
- [x] Fixes the openai.BadRequestError seen in Datadog

Generated with [Claude Code](https://claude.com/claude-code)