### PR TITLE
Fix 9 bugs from Detail CLI bug bash

### DIFF
--- a/ai_classifier.py
+++ b/ai_classifier.py
@@ -531,7 +531,7 @@ def _classify_single(
             "classifier.no_api_key",
             extra={"event": "classifier.no_api_key"},
         )
-        return is_devtools_related_fallback(text)
+        return is_devtools_related_fallback(text, name)
 
     if prompt is None:
         prompt = _get_prompt("devtools-binary-classifier", _BINARY_CLASSIFIER_FALLBACK)
@@ -557,7 +557,7 @@ def _classify_single(
                     "tool_name": name,
                 },
             )
-            return is_devtools_related_fallback(text)
+            return is_devtools_related_fallback(text, name)
         return answer == "yes"
     except Exception:
         # Intentionally broad: any classification failure degrades to keyword matching
@@ -565,7 +565,7 @@ def _classify_single(
             "classifier.single_error",
             extra={"event": "classifier.single_error", "tool_name": name},
         )
-        return is_devtools_related_fallback(text)
+        return is_devtools_related_fallback(text, name)
 
 
 def is_devtools_related_ai(text: str, name: str = "") -> bool:
@@ -577,9 +577,9 @@ def is_devtools_related_ai(text: str, name: str = "") -> bool:
     return classify_candidates([{"id": "_single", "name": name, "text": text}]).get("_single", False)
 
 
-def is_devtools_related_fallback(text: str) -> bool:
+def is_devtools_related_fallback(text: str, name: str = "") -> bool:
     """Fallback keyword-based classifier when AI is unavailable."""
-    return has_devtools_keywords(text)
+    return has_devtools_keywords(text, name)
 
 
 def get_devtools_category(text: str, name: str = "") -> str | None:

--- a/app_production.py
+++ b/app_production.py
@@ -210,7 +210,8 @@ def _teardown_request_logging(exc):
 
 def _parse_pagination(default_per_page: int = 20, max_per_page: int = 100):
     """Parse page and per_page from request args, returning (page, per_page, offset)."""
-    per_page = min(max(_safe_int(request.args.get('per_page', default_per_page), default_per_page), 1), max_per_page)
+    raw_per_page = _safe_int(request.args.get('per_page', default_per_page), default_per_page)
+    per_page = min(max(raw_per_page, 1), max_per_page)
     page = max(_safe_int(request.args.get('page', 1), 1), 1)
     offset = (page - 1) * per_page
     return page, per_page, offset
@@ -456,8 +457,6 @@ def api_chat():
             'response': 'You are sending messages too quickly. Please wait a moment and try again.',
             'tools': [],
         }), 429
-    _chat_rate_limits[client_ip].append(now)
-
     data = request.get_json(silent=True)
     user_message = (data.get("message", "") if data else "").strip()
     if not user_message:
@@ -465,6 +464,7 @@ def api_chat():
     if len(user_message) > 500:
         return jsonify({"error": "Message too long (max 500 characters)"}), 400
 
+    _chat_rate_limits[client_ip].append(now)
     result = generate_chat_response(user_message)
     logger.info(
         "api.chat",

--- a/chatbot.py
+++ b/chatbot.py
@@ -22,7 +22,10 @@ logger = get_logger("devtools.chatbot")
 
 _CHATBOT_MODEL = os.getenv("CHATBOT_MODEL", "gpt-4o-mini")
 _CHATBOT_MAX_TURNS = max(1, int(os.getenv("CHATBOT_MAX_TURNS", "3")))
-_MAX_TOOLS_IN_CONTEXT = int(os.getenv("CHATBOT_MAX_TOOLS", "10"))
+try:
+    _MAX_TOOLS_IN_CONTEXT = max(1, int(os.getenv("CHATBOT_MAX_TOOLS", "10")))
+except ValueError:
+    _MAX_TOOLS_IN_CONTEXT = 10
 
 # FTS5 operator pattern to sanitize user-supplied queries
 _FTS5_OPERATORS = re.compile(r'["\*\(\)\+\-\^:/\{\}]')

--- a/code_reviews/2026-03-20-2216-bug-bash.md
+++ b/code_reviews/2026-03-20-2216-bug-bash.md
@@ -1,0 +1,488 @@
+# Bug Bash Report -- 2026-03-20
+
+## Summary
+
+- **Repository**: codyborders/devtoolscrape
+- **Date**: 2026-03-20 22:16
+- **Bugs reviewed**: 9
+- **Bugs fixed**: 9
+- **Bugs deferred**: 0
+
+## Triage Table
+
+| # | Title | File Path | Security | Impact | Severity | Priority | Status |
+|---|-------|-----------|----------|--------|----------|----------|--------|
+| 1 | Duplicate Product Hunt post IDs waste AI classification and drop saves | scrape_producthunt_api.py | No | Medium | Major | P2 | Fixed |
+| 2 | Hacker News scraper uses current date when story timestamp is 0 | scrape_hackernews.py | No | Low | Minor | P2 | Fixed |
+| 3 | GitHub Trending scraper crashes on SQLite errors instead of logging | scrape_github_trending.py | No | High | Major | P1 | Fixed |
+| 4 | Scraper runner records success when a scraper has no configured entrypoints | scrape_all.py | No | Medium | Major | P2 | Fixed |
+| 5 | Database duplicate detection fails when startup URL is NULL | database.py | No | Medium | Major | P2 | Fixed |
+| 6 | Chatbot fails to start or returns unbounded results when CHATBOT_MAX_TOOLS is invalid | chatbot.py | No | Medium | Minor | P2 | Fixed |
+| 7 | Invalid /api/chat requests consume rate limit slots | app_production.py | No | High | Major | P1 | Fixed |
+| 8 | AI classifier fallback ignores tool name during OpenAI API failures | ai_classifier.py | No | High | Major | P1 | Fixed |
+| 9 | Observability tracing helper can block outbound calls when span setup throws | observability.py | No | High | Major | P1 | Fixed |
+
+---
+
+## Detailed Findings
+
+### Bug: Duplicate Product Hunt post IDs waste AI classification and drop saves
+
+**Detail Bug ID**: `bug_e086355d-429a-417a-a4e8-fb94a85f3485`
+**File**: `scrape_producthunt_api.py`
+**Security vulnerability**: No
+**Impact**: Medium | **Severity**: Major | **Priority**: P2
+**Status**: Fixed
+
+#### What was the problem?
+
+When the Product Hunt API returns multiple posts with the same identifier (ID, URL, or name), the scraper builds two data structures: a list called `candidates` (sent to the AI classifier) and a dictionary called `post_map` (used to save results). The list keeps every post, but the dictionary silently overwrites earlier entries with the same key. This means the AI classifier processes all posts (costing money for each API call), but only the last duplicate is saved to the database. Earlier posts are classified and then thrown away.
+
+#### What was changed?
+
+**Before:**
+```python
+candidates = []
+post_map = {}
+for post_edge in posts:
+    post = post_edge['node']
+    name = post['name']
+    tagline = post.get('tagline', '')
+    description = post.get('description', '')
+    full_text = f"{name} {tagline} {description}"
+    post_id_val = post.get('id')
+    post_identifier = post_id_val if post_id_val is not None else (post.get('url') or name)
+    post_id = str(post_identifier)
+    post_map[post_id] = (post, name, tagline, description, full_text)
+    candidates.append({"id": post_id, "name": name, "text": full_text})
+```
+
+**After:**
+```python
+candidates = []
+post_map = {}
+seen_ids = set()
+for post_edge in posts:
+    post = post_edge['node']
+    name = post['name']
+    tagline = post.get('tagline', '')
+    description = post.get('description', '')
+    full_text = f"{name} {tagline} {description}"
+    post_id_val = post.get('id')
+    post_identifier = post_id_val if post_id_val is not None else (post.get('url') or name)
+    post_id = str(post_identifier)
+    if post_id in seen_ids:
+        logger.warning(
+            "scraper.duplicate_post_id",
+            extra={"event": "scraper.duplicate_post_id", "post_id": post_id},
+        )
+        continue
+    seen_ids.add(post_id)
+    post_map[post_id] = (post, name, tagline, description, full_text)
+    candidates.append({"id": post_id, "name": name, "text": full_text})
+```
+
+#### How does the code work?
+
+1. A new `set` called `seen_ids` tracks which post identifiers have already been processed.
+2. Before adding a post to `post_map` and `candidates`, we check if its `post_id` is already in `seen_ids`.
+3. If the ID was already seen, we log a warning with the duplicate ID and skip to the next post using `continue`.
+4. If the ID is new, we add it to `seen_ids` and proceed as before.
+
+#### Why was this change needed?
+
+Without deduplication, the scraper wastes AI classification API calls on posts that will never be saved. The `candidates` list and `post_map` dictionary are now always in sync -- every post sent to the classifier will also be saved if classified as a devtool.
+
+---
+
+### Bug: Hacker News scraper uses current date when story timestamp is 0
+
+**Detail Bug ID**: `bug_481da401-c073-4422-af5c-8c34724b8497`
+**File**: `scrape_hackernews.py`
+**Security vulnerability**: No
+**Impact**: Low | **Severity**: Minor | **Priority**: P2
+**Status**: Fixed
+
+#### What was the problem?
+
+The scraper converts each Hacker News story's Unix timestamp into a Python datetime. It used the `or` operator as a fallback: `story.get('time') or datetime.now().timestamp()`. In Python, the number `0` is "falsy" (treated as `False` in boolean contexts), so a valid timestamp of `0` (which represents January 1, 1970) would trigger the fallback and be replaced with the current date and time.
+
+#### What was changed?
+
+**Before:**
+```python
+"date_found": datetime.fromtimestamp(story.get('time') or datetime.now().timestamp()),
+```
+
+**After:**
+```python
+"date_found": datetime.fromtimestamp(
+    story.get('time') if story.get('time') is not None else datetime.now().timestamp()
+),
+```
+
+#### How does the code work?
+
+1. `story.get('time')` retrieves the Unix timestamp from the story data. If the key is missing, it returns `None`.
+2. The `if ... is not None` check explicitly tests whether the value is missing (`None`), rather than relying on Python's truthiness rules.
+3. If the timestamp exists (even if it is `0`), we use it directly. Only when it is truly absent do we fall back to the current time.
+
+#### Why was this change needed?
+
+The `or` operator treats `0`, `""`, `[]`, and `None` all as falsy. By switching to an explicit `is not None` check, we preserve valid zero timestamps while still handling missing data correctly. This prevents silent data corruption in date ordering.
+
+---
+
+### Bug: GitHub Trending scraper crashes on SQLite errors instead of logging
+
+**Detail Bug ID**: `bug_4c31b0da-9171-49cb-9457-c0a68bc63ef8`
+**File**: `scrape_github_trending.py`
+**Security vulnerability**: No
+**Impact**: High | **Severity**: Major | **Priority**: P1
+**Status**: Fixed
+
+#### What was the problem?
+
+The `scrape_github_trending()` function wraps its main logic in a `try` block, but the `except` clauses only catch request errors (`requests.RequestException`) and a narrow set of parse/type errors (`KeyError, TypeError, ValueError, AttributeError`). The `save_startup()` function can raise `sqlite3.Error` subclasses (like `sqlite3.OperationalError: database is locked`), which were not caught. A transient database error would crash the entire scrape run and lose all results.
+
+#### What was changed?
+
+**Before:**
+```python
+except (KeyError, TypeError, ValueError, AttributeError):
+    logger.exception("scraper.parse_error", extra={"event": "scraper.parse_error"})
+```
+
+**After:**
+```python
+except (KeyError, TypeError, ValueError, AttributeError, sqlite3.Error):
+    logger.exception("scraper.parse_error", extra={"event": "scraper.parse_error"})
+```
+
+#### How does the code work?
+
+1. The `except` clause now includes `sqlite3.Error`, which is the base class for all SQLite-related exceptions (including `OperationalError`, `IntegrityError`, etc.).
+2. When a database error occurs during `save_startup()`, the error is logged with full traceback instead of crashing the process.
+3. This matches the pattern used by `scrape_hackernews.py`, which uses a broad `except Exception` handler around its save operations.
+
+#### Why was this change needed?
+
+Transient database issues (temporary locking, disk full) should not cause a complete loss of the scrape run. The scraper should log the error and allow monitoring systems to alert on it, rather than crashing silently.
+
+---
+
+### Bug: Scraper runner records success when a scraper has no configured entrypoints
+
+**Detail Bug ID**: `bug_33141a74-c26c-4607-bb55-b918d0db10c7`
+**File**: `scrape_all.py`
+**Security vulnerability**: No
+**Impact**: Medium | **Severity**: Major | **Priority**: P2
+**Status**: Fixed
+
+#### What was the problem?
+
+The `run_scraper()` function checks the `SCRAPER_ENTRYPOINTS` dictionary for functions to call. If a scraper module is not listed (or has an empty list), the function logs a warning but then falls through to return `True` (success). This means the `scrape_log` database table records the scraper as "successful" even though no scraping work was performed.
+
+#### What was changed?
+
+**Before:**
+```python
+else:
+    logger.warning(
+        "runner.missing_entrypoint",
+        extra={"event": "runner.missing_entrypoint"},
+    )
+```
+
+**After:**
+```python
+else:
+    logger.warning(
+        "runner.missing_entrypoint",
+        extra={"event": "runner.missing_entrypoint"},
+    )
+    return False
+```
+
+#### How does the code work?
+
+1. When `SCRAPER_ENTRYPOINTS.get(module_name)` returns `None` or an empty list, the code enters the `else` branch.
+2. A warning is logged so operators know the configuration is missing.
+3. The function now returns `False` immediately, signaling to the caller that this scraper did not complete successfully.
+4. Two tests that previously asserted `True` for missing entrypoints were updated to assert `False`.
+
+#### Why was this change needed?
+
+Returning `True` when no work is done misleads monitoring systems and developers. If someone adds a new scraper module to `main()` but forgets to register its entrypoints, the success record masks the configuration error.
+
+---
+
+### Bug: Database duplicate detection fails when startup URL is NULL
+
+**Detail Bug ID**: `bug_1b5c40d8-f2a9-4c6a-89b1-017f11d7ffee`
+**File**: `database.py`
+**Security vulnerability**: No
+**Impact**: Medium | **Severity**: Major | **Priority**: P2
+**Status**: Fixed
+
+#### What was the problem?
+
+The `is_duplicate()` function uses the SQL equality operator (`url = ?`) to check for existing records. In SQL, `NULL = NULL` evaluates to `UNKNOWN` (not `TRUE`), so when `url` is `None`, the query never matches existing rows with NULL URLs. This allows multiple startups with NULL URLs to be inserted, bypassing duplicate detection.
+
+#### What was changed?
+
+**Before:**
+```python
+def is_duplicate(name: str, url: str) -> bool:
+    """Check if a startup already exists by name or URL."""
+    with _db_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute("SELECT COUNT(*) FROM startups WHERE name = ? OR url = ?", (name, url))
+        count = cursor.fetchone()[0]
+```
+
+**After:**
+```python
+def is_duplicate(name: str, url: str) -> bool:
+    """Check if a startup already exists by name or URL."""
+    with _db_connection() as conn:
+        cursor = conn.cursor()
+        if url is None:
+            cursor.execute(
+                "SELECT COUNT(*) FROM startups WHERE name = ? OR url IS NULL",
+                (name,),
+            )
+        else:
+            cursor.execute(
+                "SELECT COUNT(*) FROM startups WHERE name = ? OR url = ?",
+                (name, url),
+            )
+        count = cursor.fetchone()[0]
+```
+
+#### How does the code work?
+
+1. Before running the query, we check if `url` is `None` in Python.
+2. If `url` is `None`, we use `url IS NULL` in the SQL WHERE clause. This is the correct SQL syntax for comparing against NULL values.
+3. If `url` has a value, we use the standard `url = ?` parameterized query as before.
+4. This ensures that duplicate detection works correctly regardless of whether URLs are present or absent.
+
+#### Why was this change needed?
+
+SQL's three-valued logic means `NULL = NULL` is not `TRUE`. Without special handling, any startup with a NULL URL could be inserted multiple times, polluting the database. Although current scrapers typically provide empty strings rather than `None`, this fix makes the function correct for all inputs.
+
+---
+
+### Bug: Chatbot fails to start or returns unbounded results when CHATBOT_MAX_TOOLS is invalid
+
+**Detail Bug ID**: `bug_f91cd541-91b2-4b07-b40a-82ad41f08552`
+**File**: `chatbot.py`
+**Security vulnerability**: No
+**Impact**: Medium | **Severity**: Minor | **Priority**: P2
+**Status**: Fixed
+
+#### What was the problem?
+
+The `CHATBOT_MAX_TOOLS` environment variable was converted to an integer without any validation. If set to a non-numeric value (like an empty string), the application would crash at startup with a `ValueError`. If set to `0`, database searches would return zero results. If set to a negative number, SQLite would treat `LIMIT -1` as "no limit," potentially returning all rows. The adjacent `CHATBOT_MAX_TURNS` variable already had `max(1, ...)` protection, but `CHATBOT_MAX_TOOLS` was left unguarded.
+
+#### What was changed?
+
+**Before:**
+```python
+_MAX_TOOLS_IN_CONTEXT = int(os.getenv("CHATBOT_MAX_TOOLS", "10"))
+```
+
+**After:**
+```python
+try:
+    _MAX_TOOLS_IN_CONTEXT = max(1, int(os.getenv("CHATBOT_MAX_TOOLS", "10")))
+except ValueError:
+    _MAX_TOOLS_IN_CONTEXT = 10
+```
+
+#### How does the code work?
+
+1. The `try/except ValueError` block catches non-numeric environment variable values and falls back to the default of 10.
+2. `max(1, ...)` ensures the value is at least 1, preventing zero or negative values from reaching database queries.
+3. This matches the validation pattern already used for `_CHATBOT_MAX_TURNS` on the line above.
+
+#### Why was this change needed?
+
+Environment variables are a system boundary where input validation is essential. A typo or misconfiguration should not crash the entire application or create unbounded database queries.
+
+---
+
+### Bug: Invalid /api/chat requests consume rate limit slots
+
+**Detail Bug ID**: `bug_ec9619c6-098a-4ad5-b669-18e5bed32018`
+**File**: `app_production.py`
+**Security vulnerability**: No
+**Impact**: High | **Severity**: Major | **Priority**: P1
+**Status**: Fixed
+
+#### What was the problem?
+
+The `/api/chat` endpoint appended the current timestamp to the rate limit tracker before validating the request body. Invalid requests (empty messages or messages over 500 characters) would return a 400 error but still consume one of the rate limit slots. An attacker could send 10 invalid requests to exhaust a legitimate user's rate limit for 60 seconds, without ever using any OpenAI API credits.
+
+#### What was changed?
+
+**Before:**
+```python
+_chat_rate_limits[client_ip].append(now)
+
+data = request.get_json(silent=True)
+user_message = (data.get("message", "") if data else "").strip()
+if not user_message:
+    return jsonify({"error": "Message is required"}), 400
+if len(user_message) > 500:
+    return jsonify({"error": "Message too long (max 500 characters)"}), 400
+
+result = generate_chat_response(user_message)
+```
+
+**After:**
+```python
+data = request.get_json(silent=True)
+user_message = (data.get("message", "") if data else "").strip()
+if not user_message:
+    return jsonify({"error": "Message is required"}), 400
+if len(user_message) > 500:
+    return jsonify({"error": "Message too long (max 500 characters)"}), 400
+
+_chat_rate_limits[client_ip].append(now)
+result = generate_chat_response(user_message)
+```
+
+#### How does the code work?
+
+1. The rate limit cleanup and check remain at the top of the function (unchanged). This still prevents excessive requests from getting through.
+2. The request body is now validated (empty check, length check) before the timestamp is appended to the rate limit list.
+3. Only requests that pass validation and proceed to the actual chatbot processing count toward the rate limit.
+4. Invalid requests are rejected with 400 errors without consuming any rate limit slots.
+
+#### Why was this change needed?
+
+Rate limiting should protect expensive resources (OpenAI API calls). Counting rejected requests toward the limit allows a denial-of-service attack where cheap invalid requests block legitimate users from accessing the chatbot.
+
+---
+
+### Bug: AI classifier fallback ignores tool name during OpenAI API failures
+
+**Detail Bug ID**: `bug_e19bd309-30bf-48c3-8cfa-55bbec6be707`
+**File**: `ai_classifier.py`
+**Security vulnerability**: No
+**Impact**: High | **Severity**: Major | **Priority**: P1
+**Status**: Fixed
+
+#### What was the problem?
+
+When the OpenAI API is unavailable (no API key, rate limit, unexpected response, or exception), the classifier falls back to keyword-based matching via `is_devtools_related_fallback()`. This function only checked the tool's description text, ignoring the tool name. The underlying `has_devtools_keywords()` function is designed to check both name and description, but the fallback never passed the name. Tools like "GitHub CLI" or "Kubernetes Dashboard" with devtools keywords in their names would be incorrectly classified as non-devtools during API outages.
+
+#### What was changed?
+
+**Before:**
+```python
+def is_devtools_related_fallback(text: str) -> bool:
+    """Fallback keyword-based classifier when AI is unavailable."""
+    return has_devtools_keywords(text)
+```
+
+Call sites:
+```python
+return is_devtools_related_fallback(text)  # 3 locations
+```
+
+**After:**
+```python
+def is_devtools_related_fallback(text: str, name: str = "") -> bool:
+    """Fallback keyword-based classifier when AI is unavailable."""
+    return has_devtools_keywords(text, name)
+```
+
+Call sites:
+```python
+return is_devtools_related_fallback(text, name)  # 3 locations
+```
+
+#### How does the code work?
+
+1. The `is_devtools_related_fallback()` function now accepts an optional `name` parameter (defaulting to empty string for backward compatibility).
+2. It passes both `text` and `name` to `has_devtools_keywords()`, which concatenates them and searches the combined string for devtools-related patterns.
+3. All three call sites in `_classify_single()` (no API key, unexpected answer, exception) now pass the `name` variable that is already available in scope.
+
+#### Why was this change needed?
+
+During API outages, the fallback classifier is the only line of defense. Ignoring tool names means devtools with keyword-rich names but generic descriptions are lost from the database. This creates data gaps specifically during the times when resilience matters most.
+
+---
+
+### Bug: Observability tracing helper can block outbound calls when span setup throws
+
+**Detail Bug ID**: `bug_06c7cf29-9e6c-44a7-92de-a2dd2e75f58f`
+**File**: `observability.py`
+**Security vulnerability**: No
+**Impact**: High | **Severity**: Major | **Priority**: P1
+**Status**: Fixed
+
+#### What was the problem?
+
+The `trace_http_call()` and `trace_external_call()` context managers protect the `tracer.trace()` call with a `try/except`, but the subsequent `span.set_tag()` calls were unprotected. If `set_tag()` raised an exception (e.g., due to a corrupted span object or an unexpected attribute type), the exception would propagate to the caller, preventing the actual HTTP request or API call from executing. This violates the design principle that tracing should never block operations.
+
+#### What was changed?
+
+**Before (trace_http_call):**
+```python
+with ctx as span:
+    span.set_tag("http.method", method.upper())
+    span.set_tag("http.url", url)
+    yield span
+```
+
+**After (trace_http_call):**
+```python
+with ctx as span:
+    try:
+        span.set_tag("http.method", method.upper())
+        span.set_tag("http.url", url)
+    except Exception:
+        span = None
+    yield span
+```
+
+**Before (trace_external_call):**
+```python
+with ctx as span:
+    if tags:
+        for key, value in tags.items():
+            span.set_tag(key, value)
+    yield span
+```
+
+**After (trace_external_call):**
+```python
+with ctx as span:
+    try:
+        if tags:
+            for key, value in tags.items():
+                span.set_tag(key, value)
+    except Exception:
+        span = None
+    yield span
+```
+
+#### How does the code work?
+
+1. The `with ctx as span:` block manages the span lifecycle (opening and closing). This is left intact so spans are always properly closed.
+2. Inside the `with` block, the `try/except` wraps only the `set_tag()` calls -- the part that can fail due to bad data or span issues.
+3. If any tag-setting operation fails, `span` is set to `None` so the caller knows tracing is unavailable, but the `yield` still happens and the caller's code executes normally.
+4. The caller's exceptions are not caught because the `except` block does not wrap the `yield` statement.
+
+#### Why was this change needed?
+
+Observability code should be strictly best-effort. A bug in tracing should never prevent the application from making HTTP requests or calling external APIs. The existing protection around `tracer.trace()` was incomplete -- this fix extends the same principle to the span setup phase.
+
+---
+
+## Deferred Issues
+
+No bugs were deferred. All 9 bugs were fixed.

--- a/database.py
+++ b/database.py
@@ -88,7 +88,6 @@ def _db_connection() -> Iterator[sqlite3.Connection]:
         conn.close()
 
 
-
 def _append_pagination(query: str, params: list, limit: Optional[int], offset: Optional[int]) -> tuple[str, list]:
     """Append LIMIT/OFFSET clauses to a SQL query string, returning the updated query and params."""
     if limit is not None:
@@ -178,7 +177,16 @@ def is_duplicate(name: str, url: str) -> bool:
     """Check if a startup already exists by name or URL."""
     with _db_connection() as conn:
         cursor = conn.cursor()
-        cursor.execute("SELECT COUNT(*) FROM startups WHERE name = ? OR url = ?", (name, url))
+        if url is None:
+            cursor.execute(
+                "SELECT COUNT(*) FROM startups WHERE name = ? OR url IS NULL",
+                (name,),
+            )
+        else:
+            cursor.execute(
+                "SELECT COUNT(*) FROM startups WHERE name = ? OR url = ?",
+                (name, url),
+            )
         count = cursor.fetchone()[0]
     logger.debug(
         "db.is_duplicate",

--- a/observability.py
+++ b/observability.py
@@ -47,8 +47,11 @@ def trace_http_call(
         return
 
     with ctx as span:
-        span.set_tag("http.method", method.upper())
-        span.set_tag("http.url", url)
+        try:
+            span.set_tag("http.method", method.upper())
+            span.set_tag("http.url", url)
+        except Exception:
+            span = None
         yield span
 
 
@@ -77,7 +80,10 @@ def trace_external_call(
         return
 
     with ctx as span:
-        if tags:
-            for key, value in tags.items():
-                span.set_tag(key, value)
+        try:
+            if tags:
+                for key, value in tags.items():
+                    span.set_tag(key, value)
+        except Exception:
+            span = None
         yield span

--- a/scrape_all.py
+++ b/scrape_all.py
@@ -44,6 +44,7 @@ def run_scraper(module_name: str, description: str) -> bool:
                     "runner.missing_entrypoint",
                     extra={"event": "runner.missing_entrypoint"},
                 )
+                return False
         except Exception:
             # Intentionally broad: scraper modules may raise arbitrary exceptions
             logger.exception(

--- a/scrape_github_trending.py
+++ b/scrape_github_trending.py
@@ -126,18 +126,8 @@ def scrape_github_trending() -> None:
                 devtools_count += 1
 
                 description = candidate["text"]
-                try:
-                    category = get_devtools_category(description, candidate["name"])
-                except (KeyError, TypeError, ValueError, AttributeError):
-                    logger.exception(
-                        "scraper.categorize_error",
-                        extra={
-                            "event": "scraper.categorize_error",
-                            "name": candidate.get("name"),
-                            "url": candidate.get("url"),
-                        },
-                    )
-                    category = None
+                # get_devtools_category handles its own exceptions and returns None on failure
+                category = get_devtools_category(description, candidate["name"])
                 if category:
                     description = f"[{category}] {description}" if description else f"[{category}]"
 
@@ -162,7 +152,7 @@ def scrape_github_trending() -> None:
             
         except requests.RequestException:
             logger.exception("scraper.request_failed", extra={"event": "scraper.request_failed"})
-        except (KeyError, TypeError, ValueError, AttributeError):
+        except (KeyError, TypeError, ValueError, AttributeError, sqlite3.Error):
             logger.exception("scraper.parse_error", extra={"event": "scraper.parse_error"})
 
 if __name__ == "__main__":

--- a/scrape_hackernews.py
+++ b/scrape_hackernews.py
@@ -205,11 +205,13 @@ def _scrape_hn_feed(
                 category = get_devtools_category(full_text, title)
                 description = _build_description(title, text, category)
 
+                story_time = story.get('time')
+                timestamp = story_time if story_time is not None else datetime.now().timestamp()
                 startup = {
                     "name": title,
                     "url": url,
                     "description": description,
-                    "date_found": datetime.fromtimestamp(story.get('time') or datetime.now().timestamp()),
+                    "date_found": datetime.fromtimestamp(timestamp),
                     "source": f"{source_label} (score: {score})"
                 }
 

--- a/scrape_producthunt_api.py
+++ b/scrape_producthunt_api.py
@@ -125,8 +125,8 @@ def scrape_producthunt_api():
             )
             
             data = resp.json()
-            posts = (data.get('data') or {}).get('posts', None)
-            posts = (posts or {}).get('edges', [])
+            posts_node = (data.get('data') or {}).get('posts') or {}
+            posts = posts_node.get('edges', [])
             logger.info(
                 "scraper.posts_found",
                 extra={"event": "scraper.posts_found", "count": len(posts)},
@@ -134,15 +134,24 @@ def scrape_producthunt_api():
             
             candidates = []
             post_map = {}
+            seen_ids = set()
             for post_edge in posts:
                 post = post_edge['node']
                 name = post['name']
                 tagline = post.get('tagline', '')
                 description = post.get('description', '')
                 full_text = f"{name} {tagline} {description}"
-                post_id_val = post.get('id')
-                post_identifier = post_id_val if post_id_val is not None else (post.get('url') or name)
-                post_id = str(post_identifier)
+                # Prefer API id, fall back to URL, then name for deduplication.
+                # Use explicit None check so a zero-valued id is still used.
+                raw_id = post.get('id')
+                post_id = str(raw_id if raw_id is not None else (post.get('url') or name))
+                if post_id in seen_ids:
+                    logger.warning(
+                        "scraper.duplicate_post_id",
+                        extra={"event": "scraper.duplicate_post_id", "post_id": post_id},
+                    )
+                    continue
+                seen_ids.add(post_id)
                 post_map[post_id] = (post, name, tagline, description, full_text)
                 candidates.append({"id": post_id, "name": name, "text": full_text})
 

--- a/tests/test_scrape_all.py
+++ b/tests/test_scrape_all.py
@@ -57,7 +57,7 @@ def test_run_scraper_variants(monkeypatch):
     assert scrape_all.run_scraper("scrape_github_trending", "GitHub")
     assert scrape_all.run_scraper("scrape_hackernews", "HN")
     assert scrape_all.run_scraper("scrape_producthunt_api", "PH")
-    assert scrape_all.run_scraper("missing_main", "No main")
+    assert not scrape_all.run_scraper("missing_main", "No main")
     assert not scrape_all.run_scraper("broken", "Broken")
 
     assert calls == ["github", "hn-top", "hn-show", "ph"]
@@ -135,7 +135,7 @@ def test_run_scraper_unknown_module_logs_warning(monkeypatch):
     }
     configure_loader(monkeypatch, factories)
 
-    assert scrape_all.run_scraper("unknown_scraper", "Unknown")
+    assert not scrape_all.run_scraper("unknown_scraper", "Unknown")
 
 
 def test_scrape_all_main_guard(monkeypatch):


### PR DESCRIPTION
## Summary

- Fixed 9 bugs identified by Detail CLI across 8 source files
- 4 P1 bugs (crash/data-loss risk), 5 P2 bugs (correctness/robustness)
- All 170 tests pass, no security vulnerabilities
- Full bug bash report in `code_reviews/2026-03-20-2216-bug-bash.md`

### Fixes

- **scrape_producthunt_api.py**: Deduplicate posts before AI classification to prevent wasted API calls and dropped saves
- **scrape_hackernews.py**: Use explicit `None` check for timestamp instead of `or` operator (timestamp `0` is valid)
- **scrape_github_trending.py**: Add `sqlite3.Error` to outer exception handler so DB errors log instead of crash
- **scrape_all.py**: Return `False` when scraper has no configured entrypoints instead of reporting success
- **database.py**: Handle `NULL` URLs with `IS NULL` in duplicate detection SQL
- **chatbot.py**: Validate and clamp `CHATBOT_MAX_TOOLS` env var with `max(1, ...)` and `ValueError` handling
- **app_production.py**: Move rate limit append after input validation so invalid requests don't consume slots
- **ai_classifier.py**: Pass tool name to fallback keyword classifier for accurate classification during API outages
- **observability.py**: Protect `span.set_tag()` calls in `try/except` so tracing failures don't block operations

## Test plan

- [x] All 170 existing tests pass
- [x] Updated 2 test assertions that encoded the old incorrect behavior (`test_run_scraper_variants`, `test_run_scraper_unknown_module_logs_warning`)
- [x] Code simplifier review applied

Generated with [Claude Code](https://claude.com/claude-code)